### PR TITLE
feat(auth): add register, login and JWT middleware

### DIFF
--- a/server/src/__tests__/auth.test.ts
+++ b/server/src/__tests__/auth.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import request from 'supertest'
+import { createApp } from '../app.js'
+import { prisma } from '../lib/prisma.js'
+
+const app = createApp()
+
+beforeAll(async () => {
+  await prisma.$connect()
+})
+
+afterAll(async () => {
+  await prisma.$disconnect()
+})
+
+beforeEach(async () => {
+  await prisma.habitLog.deleteMany()
+  await prisma.habit.deleteMany()
+  await prisma.user.deleteMany()
+})
+
+describe('POST /api/auth/register', () => {
+  it('returns JWT and user without password on success', async () => {
+    const res = await request(app).post('/api/auth/register').send({
+      email: 'alice@example.com',
+      password: 'secret123',
+      name: 'Alice',
+    })
+
+    expect(res.status).toBe(201)
+    expect(res.body.data.token).toBeDefined()
+    expect(res.body.data.user.email).toBe('alice@example.com')
+    expect(res.body.data.user.name).toBe('Alice')
+    expect(res.body.data.user.password).toBeUndefined()
+  })
+
+  it('returns 409 on duplicate email', async () => {
+    await request(app).post('/api/auth/register').send({
+      email: 'alice@example.com',
+      password: 'secret123',
+      name: 'Alice',
+    })
+
+    const res = await request(app).post('/api/auth/register').send({
+      email: 'alice@example.com',
+      password: 'different123',
+      name: 'Alice2',
+    })
+
+    expect(res.status).toBe(409)
+    expect(res.body.error).toBeDefined()
+  })
+
+  it('returns 400 when fields are missing', async () => {
+    const res = await request(app).post('/api/auth/register').send({
+      email: 'alice@example.com',
+    })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBeDefined()
+  })
+
+  it('returns 400 on invalid email format', async () => {
+    const res = await request(app).post('/api/auth/register').send({
+      email: 'not-an-email',
+      password: 'secret123',
+      name: 'Alice',
+    })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBeDefined()
+  })
+
+  it('returns 400 when password is shorter than 6 characters', async () => {
+    const res = await request(app).post('/api/auth/register').send({
+      email: 'alice@example.com',
+      password: 'abc',
+      name: 'Alice',
+    })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBeDefined()
+  })
+})
+
+describe('POST /api/auth/login', () => {
+  beforeEach(async () => {
+    await request(app).post('/api/auth/register').send({
+      email: 'alice@example.com',
+      password: 'secret123',
+      name: 'Alice',
+    })
+  })
+
+  it('returns JWT and user on success', async () => {
+    const res = await request(app).post('/api/auth/login').send({
+      email: 'alice@example.com',
+      password: 'secret123',
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.token).toBeDefined()
+    expect(res.body.data.user.email).toBe('alice@example.com')
+    expect(res.body.data.user.password).toBeUndefined()
+  })
+
+  it('returns 401 when password is wrong', async () => {
+    const res = await request(app).post('/api/auth/login').send({
+      email: 'alice@example.com',
+      password: 'wrongpassword',
+    })
+
+    expect(res.status).toBe(401)
+    expect(res.body.error).toBeDefined()
+  })
+
+  it('returns 401 when email does not exist', async () => {
+    const res = await request(app).post('/api/auth/login').send({
+      email: 'unknown@example.com',
+      password: 'secret123',
+    })
+
+    expect(res.status).toBe(401)
+    expect(res.body.error).toBeDefined()
+  })
+})
+
+describe('GET /api/auth/me', () => {
+  let token: string
+
+  beforeEach(async () => {
+    const res = await request(app).post('/api/auth/register').send({
+      email: 'alice@example.com',
+      password: 'secret123',
+      name: 'Alice',
+    })
+    token = res.body.data.token as string
+  })
+
+  it('returns current user when valid token is provided', async () => {
+    const res = await request(app)
+      .get('/api/auth/me')
+      .set('Authorization', `Bearer ${token}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.user.email).toBe('alice@example.com')
+    expect(res.body.data.user.password).toBeUndefined()
+  })
+
+  it('returns 401 when no token is provided', async () => {
+    const res = await request(app).get('/api/auth/me')
+
+    expect(res.status).toBe(401)
+    expect(res.body.error).toBeDefined()
+  })
+
+  it('returns 401 when token is invalid', async () => {
+    const res = await request(app)
+      .get('/api/auth/me')
+      .set('Authorization', 'Bearer invalidtoken')
+
+    expect(res.status).toBe(401)
+    expect(res.body.error).toBeDefined()
+  })
+})

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,5 +1,6 @@
 import express from 'express'
 import cors from 'cors'
+import { authRoutes } from './routes/auth.js'
 
 export function createApp() {
   const app = express()
@@ -11,6 +12,8 @@ export function createApp() {
   app.get('/health', (_req, res) => {
     res.status(200).json({ status: 'ok', timestamp: new Date().toISOString() })
   })
+
+  app.use('/api/auth', authRoutes)
 
   return app
 }

--- a/server/src/lib/prisma.ts
+++ b/server/src/lib/prisma.ts
@@ -1,0 +1,19 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined
+}
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    datasources: {
+      db: {
+        url: process.env.DATABASE_URL,
+      },
+    },
+  })
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma
+}

--- a/server/src/lib/validation.ts
+++ b/server/src/lib/validation.ts
@@ -1,0 +1,13 @@
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export function validateEmail(email: unknown): email is string {
+  return typeof email === 'string' && EMAIL_REGEX.test(email)
+}
+
+export function validatePassword(password: unknown): password is string {
+  return typeof password === 'string' && password.length >= 6
+}
+
+export function validateName(name: unknown): name is string {
+  return typeof name === 'string' && name.trim().length > 0
+}

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,0 +1,32 @@
+import type { Request, Response, NextFunction } from 'express'
+import jwt from 'jsonwebtoken'
+
+export interface AuthenticatedRequest extends Request {
+  user?: { userId: string }
+}
+
+const JWT_SECRET =
+  process.env.JWT_SECRET || 'dev-secret-change-in-production'
+
+export function requireAuth(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+): void {
+  const authHeader = req.headers.authorization
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    res.status(401).json({ error: 'Missing or invalid authorization header' })
+    return
+  }
+
+  const token = authHeader.slice(7)
+
+  try {
+    const payload = jwt.verify(token, JWT_SECRET) as { userId: string }
+    req.user = { userId: payload.userId }
+    next()
+  } catch {
+    res.status(401).json({ error: 'Invalid or expired token' })
+  }
+}

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,0 +1,89 @@
+import { Router } from 'express'
+import type { Request, Response } from 'express'
+import bcrypt from 'bcryptjs'
+import jwt from 'jsonwebtoken'
+import { prisma } from '../lib/prisma.js'
+import { validateEmail, validatePassword, validateName } from '../lib/validation.js'
+import { requireAuth } from '../middleware/auth.js'
+import type { AuthenticatedRequest } from '../middleware/auth.js'
+
+const router = Router()
+
+const JWT_SECRET =
+  process.env.JWT_SECRET || 'dev-secret-change-in-production'
+
+function signToken(userId: string): string {
+  return jwt.sign({ userId }, JWT_SECRET, { expiresIn: '7d' })
+}
+
+router.post('/register', async (req: Request, res: Response): Promise<void> => {
+  const { email, password, name } = req.body as Record<string, unknown>
+
+  if (!validateEmail(email) || !validatePassword(password) || !validateName(name)) {
+    const missing = !email || !password || !name
+    res.status(400).json({
+      error: missing ? 'email, password and name are required' : 'Invalid input',
+    })
+    return
+  }
+
+  const existing = await prisma.user.findUnique({ where: { email } })
+  if (existing) {
+    res.status(409).json({ error: 'Email already in use' })
+    return
+  }
+
+  const hash = await bcrypt.hash(password, 10)
+  const user = await prisma.user.create({
+    data: { email, password: hash, name },
+    select: { id: true, email: true, name: true, createdAt: true },
+  })
+
+  res.status(201).json({ data: { token: signToken(user.id), user } })
+})
+
+router.post('/login', async (req: Request, res: Response): Promise<void> => {
+  const { email, password } = req.body as Record<string, unknown>
+
+  if (typeof email !== 'string' || typeof password !== 'string') {
+    res.status(400).json({ error: 'email and password are required' })
+    return
+  }
+
+  const user = await prisma.user.findUnique({ where: { email } })
+  if (!user) {
+    res.status(401).json({ error: 'Invalid credentials' })
+    return
+  }
+
+  const match = await bcrypt.compare(password, user.password)
+  if (!match) {
+    res.status(401).json({ error: 'Invalid credentials' })
+    return
+  }
+
+  const { password: _pw, ...safeUser } = user
+  res.status(200).json({ data: { token: signToken(user.id), user: safeUser } })
+})
+
+router.get('/me', requireAuth, async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+  const userId = req.user?.userId
+  if (!userId) {
+    res.status(401).json({ error: 'Unauthorized' })
+    return
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { id: true, email: true, name: true, createdAt: true },
+  })
+
+  if (!user) {
+    res.status(401).json({ error: 'User not found' })
+    return
+  }
+
+  res.status(200).json({ data: { user } })
+})
+
+export { router as authRoutes }

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -4,5 +4,9 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: false,
+    env: {
+      DATABASE_URL: 'file:./test.db',
+      JWT_SECRET: 'test-secret-for-vitest',
+    },
   },
 })


### PR DESCRIPTION
## Summary
- Implements full JWT auth system with `POST /api/auth/register`, `POST /api/auth/login`, and `GET /api/auth/me` endpoints
- Adds bcrypt password hashing (10 rounds), JWT signing/verification middleware, input validation helpers, and a Prisma client singleton
- TDD: 11 passing tests covering success paths, duplicate emails (409), invalid input (400), wrong credentials (401), and protected route access

## Test plan
- [ ] `pnpm test` passes all 14 tests (12 server + 2 client)
- [ ] `POST /api/auth/register` creates a user and returns JWT (no password in response)
- [ ] `POST /api/auth/register` returns 409 on duplicate email
- [ ] `POST /api/auth/register` returns 400 on missing fields, invalid email, short password
- [ ] `POST /api/auth/login` returns JWT on valid credentials
- [ ] `POST /api/auth/login` returns 401 on wrong password or unknown email
- [ ] `GET /api/auth/me` returns user with valid Bearer token
- [ ] `GET /api/auth/me` returns 401 without token or with invalid token

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented user registration with email, password, and name validation
  * Implemented user login with JWT token-based authentication
  * Added protected endpoints requiring authentication
  * Added endpoint to retrieve current user profile

* **Tests**
  * Added comprehensive end-to-end test coverage for all authentication flows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->