### PR TITLE
feat(habits): add CRUD API with ownership checks

### DIFF
--- a/server/.env.test
+++ b/server/.env.test
@@ -1,0 +1,2 @@
+DATABASE_URL="file:./test.db"
+JWT_SECRET="test-jwt-secret"

--- a/server/src/__tests__/habits.test.ts
+++ b/server/src/__tests__/habits.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import request from 'supertest'
+import { createApp } from '../app.js'
+import { createTestUser, cleanDatabase, testPrisma } from './helpers.js'
+
+const app = createApp()
+
+beforeEach(async () => {
+  await cleanDatabase()
+})
+
+afterAll(async () => {
+  await cleanDatabase()
+  await testPrisma.$disconnect()
+})
+
+describe('POST /api/habits', () => {
+  it('creates a habit when authenticated with valid data', async () => {
+    const { token } = await createTestUser()
+
+    const res = await request(app)
+      .post('/api/habits')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Morning Run', category: 'Health', icon: '🏃' })
+
+    expect(res.status).toBe(201)
+    expect(res.body.data.name).toBe('Morning Run')
+    expect(res.body.data.category).toBe('Health')
+  })
+
+  it('returns 400 when name is missing', async () => {
+    const { token } = await createTestUser()
+
+    const res = await request(app)
+      .post('/api/habits')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ category: 'Health' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBeDefined()
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app)
+      .post('/api/habits')
+      .send({ name: 'Morning Run' })
+
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('GET /api/habits', () => {
+  it('returns list of habits for the authenticated user', async () => {
+    const { token, userId } = await createTestUser('user1@test.com')
+    await testPrisma.habit.create({ data: { userId, name: 'Habit A' } })
+    await testPrisma.habit.create({ data: { userId, name: 'Habit B' } })
+
+    const res = await request(app)
+      .get('/api/habits')
+      .set('Authorization', `Bearer ${token}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.data).toHaveLength(2)
+    expect(res.body.data.map((h: { name: string }) => h.name)).toContain('Habit A')
+  })
+
+  it('does not return other users habits', async () => {
+    const { token } = await createTestUser('user1@test.com')
+    const { userId: otherId } = await createTestUser('user2@test.com')
+    await testPrisma.habit.create({ data: { userId: otherId, name: 'Other Habit' } })
+
+    const res = await request(app)
+      .get('/api/habits')
+      .set('Authorization', `Bearer ${token}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.data).toHaveLength(0)
+  })
+
+  it('filters by category when ?category= is provided', async () => {
+    const { token, userId } = await createTestUser()
+    await testPrisma.habit.create({ data: { userId, name: 'Morning Run', category: 'Health' } })
+    await testPrisma.habit.create({ data: { userId, name: 'Read Book', category: 'Learning' } })
+
+    const res = await request(app)
+      .get('/api/habits?category=Health')
+      .set('Authorization', `Bearer ${token}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.data).toHaveLength(1)
+    expect(res.body.data[0].name).toBe('Morning Run')
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).get('/api/habits')
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('PUT /api/habits/:id', () => {
+  it('updates a habit the user owns', async () => {
+    const { token, userId } = await createTestUser()
+    const habit = await testPrisma.habit.create({ data: { userId, name: 'Old Name' } })
+
+    const res = await request(app)
+      .put(`/api/habits/${habit.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'New Name', color: '#FF0000' })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.name).toBe('New Name')
+    expect(res.body.data.color).toBe('#FF0000')
+  })
+
+  it('returns 403 when updating another users habit', async () => {
+    const { token } = await createTestUser('user1@test.com')
+    const { userId: otherId } = await createTestUser('user2@test.com')
+    const habit = await testPrisma.habit.create({ data: { userId: otherId, name: 'Other Habit' } })
+
+    const res = await request(app)
+      .put(`/api/habits/${habit.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Hacked' })
+
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).put('/api/habits/some-id').send({ name: 'x' })
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('PATCH /api/habits/:id/archive', () => {
+  it('toggles isArchived status for owned habit', async () => {
+    const { token, userId } = await createTestUser()
+    const habit = await testPrisma.habit.create({
+      data: { userId, name: 'Habit', isArchived: false },
+    })
+
+    const res = await request(app)
+      .patch(`/api/habits/${habit.id}/archive`)
+      .set('Authorization', `Bearer ${token}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.isArchived).toBe(true)
+  })
+
+  it('returns 403 when archiving another users habit', async () => {
+    const { token } = await createTestUser('user1@test.com')
+    const { userId: otherId } = await createTestUser('user2@test.com')
+    const habit = await testPrisma.habit.create({ data: { userId: otherId, name: 'Other' } })
+
+    const res = await request(app)
+      .patch(`/api/habits/${habit.id}/archive`)
+      .set('Authorization', `Bearer ${token}`)
+
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).patch('/api/habits/some-id/archive')
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('PATCH /api/habits/reorder', () => {
+  it('updates positions for habits the user owns', async () => {
+    const { token, userId } = await createTestUser()
+    const h1 = await testPrisma.habit.create({ data: { userId, name: 'H1', position: 0 } })
+    const h2 = await testPrisma.habit.create({ data: { userId, name: 'H2', position: 1 } })
+
+    const res = await request(app)
+      .patch('/api/habits/reorder')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ habits: [{ id: h1.id, position: 1 }, { id: h2.id, position: 0 }] })
+
+    expect(res.status).toBe(200)
+
+    const updated1 = await testPrisma.habit.findUnique({ where: { id: h1.id } })
+    const updated2 = await testPrisma.habit.findUnique({ where: { id: h2.id } })
+    expect(updated1?.position).toBe(1)
+    expect(updated2?.position).toBe(0)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).patch('/api/habits/reorder').send({ habits: [] })
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('DELETE /api/habits/:id', () => {
+  it('deletes a habit the user owns', async () => {
+    const { token, userId } = await createTestUser()
+    const habit = await testPrisma.habit.create({ data: { userId, name: 'To Delete' } })
+
+    const res = await request(app)
+      .delete(`/api/habits/${habit.id}`)
+      .set('Authorization', `Bearer ${token}`)
+
+    expect(res.status).toBe(204)
+
+    const deleted = await testPrisma.habit.findUnique({ where: { id: habit.id } })
+    expect(deleted).toBeNull()
+  })
+
+  it('returns 403 when deleting another users habit', async () => {
+    const { token } = await createTestUser('user1@test.com')
+    const { userId: otherId } = await createTestUser('user2@test.com')
+    const habit = await testPrisma.habit.create({ data: { userId: otherId, name: 'Other' } })
+
+    const res = await request(app)
+      .delete(`/api/habits/${habit.id}`)
+      .set('Authorization', `Bearer ${token}`)
+
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).delete('/api/habits/some-id')
+    expect(res.status).toBe(401)
+  })
+})

--- a/server/src/__tests__/habits.test.ts
+++ b/server/src/__tests__/habits.test.ts
@@ -132,7 +132,7 @@ describe('PUT /api/habits/:id', () => {
 })
 
 describe('PATCH /api/habits/:id/archive', () => {
-  it('toggles isArchived status for owned habit', async () => {
+  it('toggles isArchived status for owned habit (false → true)', async () => {
     const { token, userId } = await createTestUser()
     const habit = await testPrisma.habit.create({
       data: { userId, name: 'Habit', isArchived: false },
@@ -144,6 +144,20 @@ describe('PATCH /api/habits/:id/archive', () => {
 
     expect(res.status).toBe(200)
     expect(res.body.data.isArchived).toBe(true)
+  })
+
+  it('toggles isArchived status for owned habit (true → false)', async () => {
+    const { token, userId } = await createTestUser()
+    const habit = await testPrisma.habit.create({
+      data: { userId, name: 'Habit', isArchived: true },
+    })
+
+    const res = await request(app)
+      .patch(`/api/habits/${habit.id}/archive`)
+      .set('Authorization', `Bearer ${token}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.isArchived).toBe(false)
   })
 
   it('returns 403 when archiving another users habit', async () => {
@@ -181,6 +195,21 @@ describe('PATCH /api/habits/reorder', () => {
     const updated2 = await testPrisma.habit.findUnique({ where: { id: h2.id } })
     expect(updated1?.position).toBe(1)
     expect(updated2?.position).toBe(0)
+  })
+
+  it('returns 403 when reordering with another users habit IDs', async () => {
+    const { token } = await createTestUser('user1@test.com')
+    const { userId: otherId } = await createTestUser('user2@test.com')
+    const otherHabit = await testPrisma.habit.create({
+      data: { userId: otherId, name: 'Other Habit', position: 0 },
+    })
+
+    const res = await request(app)
+      .patch('/api/habits/reorder')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ habits: [{ id: otherHabit.id, position: 0 }] })
+
+    expect(res.status).toBe(403)
   })
 
   it('returns 401 without auth token', async () => {

--- a/server/src/__tests__/helpers.ts
+++ b/server/src/__tests__/helpers.ts
@@ -1,0 +1,29 @@
+import { PrismaClient } from '@prisma/client'
+import bcrypt from 'bcryptjs'
+import jwt from 'jsonwebtoken'
+
+const prisma = new PrismaClient()
+
+export async function createTestUser(
+  email = `test-${Date.now()}@example.com`,
+  name = 'Test User'
+): Promise<{ userId: string; token: string }> {
+  const hashedPassword = await bcrypt.hash('password123', 10)
+
+  const user = await prisma.user.create({
+    data: { email, password: hashedPassword, name },
+  })
+
+  const secret = process.env.JWT_SECRET ?? 'test-jwt-secret'
+  const token = jwt.sign({ userId: user.id }, secret, { expiresIn: '1h' })
+
+  return { userId: user.id, token }
+}
+
+export async function cleanDatabase(): Promise<void> {
+  await prisma.habitLog.deleteMany()
+  await prisma.habit.deleteMany()
+  await prisma.user.deleteMany()
+}
+
+export { prisma as testPrisma }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,9 +1,9 @@
-import express from 'express'
+import express, { Express, Request, Response, NextFunction } from 'express'
 import cors from 'cors'
 import { authMiddleware } from './middleware/auth.js'
 import habitsRouter from './routes/habits.js'
 
-export function createApp() {
+export function createApp(): Express {
   const app = express()
 
   app.use(cors())
@@ -16,6 +16,13 @@ export function createApp() {
 
   // API routes
   app.use('/api/habits', authMiddleware, habitsRouter)
+
+  // Global error handler — catches errors forwarded via next(err) from asyncHandler
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    console.error(err)
+    res.status(500).json({ error: 'Internal server error' })
+  })
 
   return app
 }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,5 +1,7 @@
 import express from 'express'
 import cors from 'cors'
+import { authMiddleware } from './middleware/auth.js'
+import habitsRouter from './routes/habits.js'
 
 export function createApp() {
   const app = express()
@@ -11,6 +13,9 @@ export function createApp() {
   app.get('/health', (_req, res) => {
     res.status(200).json({ status: 'ok', timestamp: new Date().toISOString() })
   })
+
+  // API routes
+  app.use('/api/habits', authMiddleware, habitsRouter)
 
   return app
 }

--- a/server/src/lib/prisma.ts
+++ b/server/src/lib/prisma.ts
@@ -1,0 +1,15 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined
+}
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: process.env.NODE_ENV === 'development' ? ['error', 'warn'] : ['error'],
+  })
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma
+}

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,0 +1,39 @@
+import { Request, Response, NextFunction } from 'express'
+import jwt from 'jsonwebtoken'
+
+export interface AuthRequest extends Request {
+  userId?: string
+}
+
+interface JwtPayload {
+  userId: string
+}
+
+export function authMiddleware(
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+): void {
+  const authHeader = req.headers.authorization
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    res.status(401).json({ error: 'Unauthorized' })
+    return
+  }
+
+  const token = authHeader.slice(7)
+  const secret = process.env.JWT_SECRET
+
+  if (!secret) {
+    res.status(500).json({ error: 'Server configuration error' })
+    return
+  }
+
+  try {
+    const payload = jwt.verify(token, secret) as JwtPayload
+    req.userId = payload.userId
+    next()
+  } catch {
+    res.status(401).json({ error: 'Invalid token' })
+  }
+}

--- a/server/src/routes/habits.ts
+++ b/server/src/routes/habits.ts
@@ -1,9 +1,24 @@
-import { Router, Response } from 'express'
+import { Router, IRouter, Request, Response, NextFunction } from 'express'
 import { prisma } from '../lib/prisma.js'
 import { AuthRequest } from '../middleware/auth.js'
 import { Frequency } from '@prisma/client'
 
-const router = Router()
+const router: IRouter = Router()
+
+// Utility: wrap async route handlers to forward errors to Express error handler
+function asyncHandler(
+  fn: (req: Request, res: Response, next: NextFunction) => Promise<void>
+) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    fn(req, res, next).catch(next)
+  }
+}
+
+// Utility: extract a route param as a plain string (Express 5 params are string | string[])
+function getParam(req: Request, name: string): string {
+  const value = req.params[name]
+  return Array.isArray(value) ? value[0] : value
+}
 
 interface CreateHabitBody {
   name?: unknown
@@ -38,182 +53,221 @@ function isValidFrequency(value: unknown): value is Frequency {
   return value === 'DAILY' || value === 'WEEKLY' || value === 'CUSTOM'
 }
 
+function isValidReorderEntry(value: unknown): value is ReorderEntry {
+  if (typeof value !== 'object' || value === null) return false
+  const entry = value as Record<string, unknown>
+  return (
+    typeof entry.id === 'string' &&
+    (typeof entry.position === 'number' || typeof entry.position === 'string')
+  )
+}
+
 // POST / — create habit
-router.post('/', async (req: AuthRequest, res: Response): Promise<void> => {
-  const userId = req.userId as string
-  const body = req.body as CreateHabitBody
+router.post(
+  '/',
+  asyncHandler(async (req: AuthRequest, res: Response): Promise<void> => {
+    const userId = req.userId as string
+    const body = req.body as CreateHabitBody
 
-  if (!body.name || typeof body.name !== 'string' || body.name.trim() === '') {
-    res.status(400).json({ error: 'Name is required' })
-    return
-  }
+    if (!body.name || typeof body.name !== 'string' || body.name.trim() === '') {
+      res.status(400).json({ error: 'Name is required' })
+      return
+    }
 
-  const frequency =
-    body.frequency !== undefined && isValidFrequency(body.frequency)
-      ? body.frequency
-      : undefined
+    const frequency =
+      body.frequency !== undefined && isValidFrequency(body.frequency)
+        ? body.frequency
+        : undefined
 
-  const habit = await prisma.habit.create({
-    data: {
-      userId,
-      name: body.name.trim(),
-      description:
-        typeof body.description === 'string' ? body.description : undefined,
-      icon: typeof body.icon === 'string' ? body.icon : undefined,
-      color: typeof body.color === 'string' ? body.color : undefined,
-      frequency,
-      targetDays:
-        typeof body.targetDays === 'number' ? body.targetDays : undefined,
-      category:
-        typeof body.category === 'string' ? body.category : undefined,
-    },
+    const habit = await prisma.habit.create({
+      data: {
+        userId,
+        name: body.name.trim(),
+        description:
+          typeof body.description === 'string' ? body.description : undefined,
+        icon: typeof body.icon === 'string' ? body.icon : undefined,
+        color: typeof body.color === 'string' ? body.color : undefined,
+        frequency,
+        targetDays:
+          typeof body.targetDays === 'number' ? body.targetDays : undefined,
+        category:
+          typeof body.category === 'string' ? body.category : undefined,
+      },
+    })
+
+    res.status(201).json({ data: habit })
   })
-
-  res.status(201).json({ data: habit })
-})
+)
 
 // GET / — list habits for current user
-router.get('/', async (req: AuthRequest, res: Response): Promise<void> => {
-  const userId = req.userId as string
-  const category =
-    typeof req.query.category === 'string' ? req.query.category : undefined
+router.get(
+  '/',
+  asyncHandler(async (req: AuthRequest, res: Response): Promise<void> => {
+    const userId = req.userId as string
+    const category =
+      typeof req.query.category === 'string' ? req.query.category : undefined
 
-  const habits = await prisma.habit.findMany({
-    where: {
-      userId,
-      ...(category ? { category } : {}),
-    },
-    orderBy: { position: 'asc' },
+    const habits = await prisma.habit.findMany({
+      where: {
+        userId,
+        ...(category ? { category } : {}),
+      },
+      orderBy: { position: 'asc' },
+    })
+
+    res.status(200).json({ data: habits })
   })
-
-  res.status(200).json({ data: habits })
-})
+)
 
 // PUT /:id — update habit
-router.put('/:id', async (req: AuthRequest, res: Response): Promise<void> => {
-  const userId = req.userId as string
-  const { id } = req.params
-  const body = req.body as UpdateHabitBody
+router.put(
+  '/:id',
+  asyncHandler(async (req: AuthRequest, res: Response): Promise<void> => {
+    const userId = req.userId as string
+    const id = getParam(req, 'id')
+    const body = req.body as UpdateHabitBody
 
-  const existing = await prisma.habit.findUnique({ where: { id } })
+    const existing = await prisma.habit.findUnique({ where: { id } })
 
-  if (!existing) {
-    res.status(404).json({ error: 'Habit not found' })
-    return
-  }
+    if (!existing) {
+      res.status(404).json({ error: 'Habit not found' })
+      return
+    }
 
-  if (existing.userId !== userId) {
-    res.status(403).json({ error: 'Forbidden' })
-    return
-  }
+    if (existing.userId !== userId) {
+      res.status(403).json({ error: 'Forbidden' })
+      return
+    }
 
-  const frequency =
-    body.frequency !== undefined && isValidFrequency(body.frequency)
-      ? body.frequency
-      : undefined
+    const frequency =
+      body.frequency !== undefined && isValidFrequency(body.frequency)
+        ? body.frequency
+        : undefined
 
-  const habit = await prisma.habit.update({
-    where: { id },
-    data: {
-      ...(typeof body.name === 'string' ? { name: body.name.trim() } : {}),
-      ...(typeof body.description === 'string'
-        ? { description: body.description }
-        : {}),
-      ...(typeof body.icon === 'string' ? { icon: body.icon } : {}),
-      ...(typeof body.color === 'string' ? { color: body.color } : {}),
-      ...(frequency ? { frequency } : {}),
-      ...(typeof body.targetDays === 'number'
-        ? { targetDays: body.targetDays }
-        : {}),
-      ...(typeof body.category === 'string' ? { category: body.category } : {}),
-    },
+    const habit = await prisma.habit.update({
+      where: { id },
+      data: {
+        ...(typeof body.name === 'string' ? { name: body.name.trim() } : {}),
+        ...(typeof body.description === 'string'
+          ? { description: body.description }
+          : {}),
+        ...(typeof body.icon === 'string' ? { icon: body.icon } : {}),
+        ...(typeof body.color === 'string' ? { color: body.color } : {}),
+        ...(frequency ? { frequency } : {}),
+        ...(typeof body.targetDays === 'number'
+          ? { targetDays: body.targetDays }
+          : {}),
+        ...(typeof body.category === 'string' ? { category: body.category } : {}),
+      },
+    })
+
+    res.status(200).json({ data: habit })
   })
-
-  res.status(200).json({ data: habit })
-})
+)
 
 // PATCH /reorder — update positions (must come before /:id routes)
-router.patch('/reorder', async (req: AuthRequest, res: Response): Promise<void> => {
-  const userId = req.userId as string
-  const body = req.body as ReorderBody
+router.patch(
+  '/reorder',
+  asyncHandler(async (req: AuthRequest, res: Response): Promise<void> => {
+    const userId = req.userId as string
+    const body = req.body as ReorderBody
 
-  if (!Array.isArray(body.habits)) {
-    res.status(400).json({ error: 'habits array is required' })
-    return
-  }
+    if (!Array.isArray(body.habits)) {
+      res.status(400).json({ error: 'habits array is required' })
+      return
+    }
 
-  const entries = body.habits as ReorderEntry[]
+    // Validate each entry has id (string) and position (string or number)
+    const invalidEntry = body.habits.find((e) => !isValidReorderEntry(e))
+    if (invalidEntry !== undefined) {
+      res
+        .status(400)
+        .json({ error: 'Each entry must have a string id and numeric position' })
+      return
+    }
 
-  // Verify all habits belong to the requesting user
-  const ids = entries.map((e) => e.id)
-  const habits = await prisma.habit.findMany({
-    where: { id: { in: ids } },
-    select: { id: true, userId: true },
-  })
+    const entries: ReorderEntry[] = body.habits.map((e) => ({
+      id: (e as ReorderEntry).id,
+      position: Number((e as ReorderEntry).position),
+    }))
 
-  const notOwned = habits.some((h) => h.userId !== userId)
-  if (notOwned || habits.length !== ids.length) {
-    res.status(403).json({ error: 'Forbidden' })
-    return
-  }
+    // Verify all habits belong to the requesting user
+    const ids = entries.map((e) => e.id)
+    const habits = await prisma.habit.findMany({
+      where: { id: { in: ids } },
+      select: { id: true, userId: true },
+    })
 
-  await prisma.$transaction(
-    entries.map((entry) =>
-      prisma.habit.update({
-        where: { id: entry.id },
-        data: { position: entry.position },
-      })
+    const notOwned = habits.some((h) => h.userId !== userId)
+    if (notOwned || habits.length !== ids.length) {
+      res.status(403).json({ error: 'Forbidden' })
+      return
+    }
+
+    await prisma.$transaction(
+      entries.map((entry) =>
+        prisma.habit.update({
+          where: { id: entry.id },
+          data: { position: entry.position },
+        })
+      )
     )
-  )
 
-  res.status(200).json({ message: 'Positions updated' })
-})
+    res.status(200).json({ message: 'Positions updated' })
+  })
+)
 
 // PATCH /:id/archive — toggle archive status
-router.patch('/:id/archive', async (req: AuthRequest, res: Response): Promise<void> => {
-  const userId = req.userId as string
-  const { id } = req.params
+router.patch(
+  '/:id/archive',
+  asyncHandler(async (req: AuthRequest, res: Response): Promise<void> => {
+    const userId = req.userId as string
+    const id = getParam(req, 'id')
 
-  const existing = await prisma.habit.findUnique({ where: { id } })
+    const existing = await prisma.habit.findUnique({ where: { id } })
 
-  if (!existing) {
-    res.status(404).json({ error: 'Habit not found' })
-    return
-  }
+    if (!existing) {
+      res.status(404).json({ error: 'Habit not found' })
+      return
+    }
 
-  if (existing.userId !== userId) {
-    res.status(403).json({ error: 'Forbidden' })
-    return
-  }
+    if (existing.userId !== userId) {
+      res.status(403).json({ error: 'Forbidden' })
+      return
+    }
 
-  const habit = await prisma.habit.update({
-    where: { id },
-    data: { isArchived: !existing.isArchived },
+    const habit = await prisma.habit.update({
+      where: { id },
+      data: { isArchived: !existing.isArchived },
+    })
+
+    res.status(200).json({ data: habit })
   })
-
-  res.status(200).json({ data: habit })
-})
+)
 
 // DELETE /:id — delete habit
-router.delete('/:id', async (req: AuthRequest, res: Response): Promise<void> => {
-  const userId = req.userId as string
-  const { id } = req.params
+router.delete(
+  '/:id',
+  asyncHandler(async (req: AuthRequest, res: Response): Promise<void> => {
+    const userId = req.userId as string
+    const id = getParam(req, 'id')
 
-  const existing = await prisma.habit.findUnique({ where: { id } })
+    const existing = await prisma.habit.findUnique({ where: { id } })
 
-  if (!existing) {
-    res.status(404).json({ error: 'Habit not found' })
-    return
-  }
+    if (!existing) {
+      res.status(404).json({ error: 'Habit not found' })
+      return
+    }
 
-  if (existing.userId !== userId) {
-    res.status(403).json({ error: 'Forbidden' })
-    return
-  }
+    if (existing.userId !== userId) {
+      res.status(403).json({ error: 'Forbidden' })
+      return
+    }
 
-  await prisma.habit.delete({ where: { id } })
+    await prisma.habit.delete({ where: { id } })
 
-  res.status(204).send()
-})
+    res.status(204).send()
+  })
+)
 
 export default router

--- a/server/src/routes/habits.ts
+++ b/server/src/routes/habits.ts
@@ -1,0 +1,219 @@
+import { Router, Response } from 'express'
+import { prisma } from '../lib/prisma.js'
+import { AuthRequest } from '../middleware/auth.js'
+import { Frequency } from '@prisma/client'
+
+const router = Router()
+
+interface CreateHabitBody {
+  name?: unknown
+  description?: unknown
+  icon?: unknown
+  color?: unknown
+  frequency?: unknown
+  targetDays?: unknown
+  category?: unknown
+}
+
+interface UpdateHabitBody {
+  name?: unknown
+  description?: unknown
+  icon?: unknown
+  color?: unknown
+  frequency?: unknown
+  targetDays?: unknown
+  category?: unknown
+}
+
+interface ReorderEntry {
+  id: string
+  position: number
+}
+
+interface ReorderBody {
+  habits?: unknown
+}
+
+function isValidFrequency(value: unknown): value is Frequency {
+  return value === 'DAILY' || value === 'WEEKLY' || value === 'CUSTOM'
+}
+
+// POST / — create habit
+router.post('/', async (req: AuthRequest, res: Response): Promise<void> => {
+  const userId = req.userId as string
+  const body = req.body as CreateHabitBody
+
+  if (!body.name || typeof body.name !== 'string' || body.name.trim() === '') {
+    res.status(400).json({ error: 'Name is required' })
+    return
+  }
+
+  const frequency =
+    body.frequency !== undefined && isValidFrequency(body.frequency)
+      ? body.frequency
+      : undefined
+
+  const habit = await prisma.habit.create({
+    data: {
+      userId,
+      name: body.name.trim(),
+      description:
+        typeof body.description === 'string' ? body.description : undefined,
+      icon: typeof body.icon === 'string' ? body.icon : undefined,
+      color: typeof body.color === 'string' ? body.color : undefined,
+      frequency,
+      targetDays:
+        typeof body.targetDays === 'number' ? body.targetDays : undefined,
+      category:
+        typeof body.category === 'string' ? body.category : undefined,
+    },
+  })
+
+  res.status(201).json({ data: habit })
+})
+
+// GET / — list habits for current user
+router.get('/', async (req: AuthRequest, res: Response): Promise<void> => {
+  const userId = req.userId as string
+  const category =
+    typeof req.query.category === 'string' ? req.query.category : undefined
+
+  const habits = await prisma.habit.findMany({
+    where: {
+      userId,
+      ...(category ? { category } : {}),
+    },
+    orderBy: { position: 'asc' },
+  })
+
+  res.status(200).json({ data: habits })
+})
+
+// PUT /:id — update habit
+router.put('/:id', async (req: AuthRequest, res: Response): Promise<void> => {
+  const userId = req.userId as string
+  const { id } = req.params
+  const body = req.body as UpdateHabitBody
+
+  const existing = await prisma.habit.findUnique({ where: { id } })
+
+  if (!existing) {
+    res.status(404).json({ error: 'Habit not found' })
+    return
+  }
+
+  if (existing.userId !== userId) {
+    res.status(403).json({ error: 'Forbidden' })
+    return
+  }
+
+  const frequency =
+    body.frequency !== undefined && isValidFrequency(body.frequency)
+      ? body.frequency
+      : undefined
+
+  const habit = await prisma.habit.update({
+    where: { id },
+    data: {
+      ...(typeof body.name === 'string' ? { name: body.name.trim() } : {}),
+      ...(typeof body.description === 'string'
+        ? { description: body.description }
+        : {}),
+      ...(typeof body.icon === 'string' ? { icon: body.icon } : {}),
+      ...(typeof body.color === 'string' ? { color: body.color } : {}),
+      ...(frequency ? { frequency } : {}),
+      ...(typeof body.targetDays === 'number'
+        ? { targetDays: body.targetDays }
+        : {}),
+      ...(typeof body.category === 'string' ? { category: body.category } : {}),
+    },
+  })
+
+  res.status(200).json({ data: habit })
+})
+
+// PATCH /reorder — update positions (must come before /:id routes)
+router.patch('/reorder', async (req: AuthRequest, res: Response): Promise<void> => {
+  const userId = req.userId as string
+  const body = req.body as ReorderBody
+
+  if (!Array.isArray(body.habits)) {
+    res.status(400).json({ error: 'habits array is required' })
+    return
+  }
+
+  const entries = body.habits as ReorderEntry[]
+
+  // Verify all habits belong to the requesting user
+  const ids = entries.map((e) => e.id)
+  const habits = await prisma.habit.findMany({
+    where: { id: { in: ids } },
+    select: { id: true, userId: true },
+  })
+
+  const notOwned = habits.some((h) => h.userId !== userId)
+  if (notOwned || habits.length !== ids.length) {
+    res.status(403).json({ error: 'Forbidden' })
+    return
+  }
+
+  await prisma.$transaction(
+    entries.map((entry) =>
+      prisma.habit.update({
+        where: { id: entry.id },
+        data: { position: entry.position },
+      })
+    )
+  )
+
+  res.status(200).json({ message: 'Positions updated' })
+})
+
+// PATCH /:id/archive — toggle archive status
+router.patch('/:id/archive', async (req: AuthRequest, res: Response): Promise<void> => {
+  const userId = req.userId as string
+  const { id } = req.params
+
+  const existing = await prisma.habit.findUnique({ where: { id } })
+
+  if (!existing) {
+    res.status(404).json({ error: 'Habit not found' })
+    return
+  }
+
+  if (existing.userId !== userId) {
+    res.status(403).json({ error: 'Forbidden' })
+    return
+  }
+
+  const habit = await prisma.habit.update({
+    where: { id },
+    data: { isArchived: !existing.isArchived },
+  })
+
+  res.status(200).json({ data: habit })
+})
+
+// DELETE /:id — delete habit
+router.delete('/:id', async (req: AuthRequest, res: Response): Promise<void> => {
+  const userId = req.userId as string
+  const { id } = req.params
+
+  const existing = await prisma.habit.findUnique({ where: { id } })
+
+  if (!existing) {
+    res.status(404).json({ error: 'Habit not found' })
+    return
+  }
+
+  if (existing.userId !== userId) {
+    res.status(403).json({ error: 'Forbidden' })
+    return
+  }
+
+  await prisma.habit.delete({ where: { id } })
+
+  res.status(204).send()
+})
+
+export default router

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -4,5 +4,15 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: false,
+    env: {
+      DATABASE_URL: 'file:./test.db',
+      JWT_SECRET: 'test-jwt-secret',
+    },
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
   },
 })


### PR DESCRIPTION
## Summary
- Implements full habits CRUD REST API under `/api/habits` with JWT auth middleware protecting all routes
- Adds ownership verification on PUT, PATCH (archive/reorder), and DELETE to prevent cross-user data access
- TDD approach: 18 passing integration tests covering all endpoints, auth checks, and ownership enforcement

## New files
- `server/src/lib/prisma.ts` — Prisma client singleton
- `server/src/middleware/auth.ts` — JWT Bearer token verification, attaches `req.userId`
- `server/src/routes/habits.ts` — Express Router (POST, GET, PUT, PATCH archive, PATCH reorder, DELETE)
- `server/src/__tests__/habits.test.ts` — 18 integration tests (supertest + vitest)
- `server/src/__tests__/helpers.ts` — `createTestUser()` and `cleanDatabase()` test helpers

## Test plan
- [x] `pnpm test` in server workspace: 19/19 tests pass (18 habits + 1 health)
- [x] POST /api/habits — creates habit, 400 on missing name, 401 without token
- [x] GET /api/habits — returns only owner's habits, filters by `?category=`, 401 without token
- [x] PUT /api/habits/:id — updates habit, 403 on other user's habit, 401 without token
- [x] PATCH /api/habits/:id/archive — toggles isArchived, 403 on other user's habit
- [x] PATCH /api/habits/reorder — updates positions in transaction, 401 without token
- [x] DELETE /api/habits/:id — deletes habit, 403 on other user's habit, 401 without token

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Habits management API with full CRUD, archiving, reordering, and category filtering; all habits endpoints require authentication
* **Tests**
  * Comprehensive integration tests covering habits lifecycle, authorization, filtering, reordering, archiving, and deletion
* **Chores**
  * Test environment and test runtime configuration added for reliable test execution
<!-- end of auto-generated comment: release notes by coderabbit.ai -->