### PR TITLE
feat(habits): add CRUD API with ownership checks

### DIFF
--- a/server/src/__tests__/habits.test.ts
+++ b/server/src/__tests__/habits.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import request from 'supertest'
+import { createApp } from '../app.js'
+import { createTestUser, cleanDatabase } from './helpers.js'
+import { prisma } from '../lib/prisma.js'
+
+const app = createApp()
+
+beforeEach(async () => {
+  await cleanDatabase()
+})
+
+describe('POST /api/habits', () => {
+  it('creates a habit when authenticated with valid data', async () => {
+    const { token } = await createTestUser()
+    const res = await request(app)
+      .post('/api/habits')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Meditation', icon: '🧘', color: '#7DD3B4', category: 'Health' })
+
+    expect(res.status).toBe(201)
+    expect(res.body.data.name).toBe('Meditation')
+    expect(res.body.data.icon).toBe('🧘')
+    expect(res.body.data.category).toBe('Health')
+  })
+
+  it('returns 400 when name is missing', async () => {
+    const { token } = await createTestUser()
+    const res = await request(app)
+      .post('/api/habits')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ icon: '🧘' })
+
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).post('/api/habits').send({ name: 'Test' })
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('GET /api/habits', () => {
+  it('returns list of habits for the authenticated user', async () => {
+    const { userId, token } = await createTestUser()
+    await prisma.habit.create({ data: { userId, name: 'Habit A', position: 0 } })
+    await prisma.habit.create({ data: { userId, name: 'Habit B', position: 1 } })
+
+    const res = await request(app)
+      .get('/api/habits')
+      .set('Authorization', `Bearer ${token}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.data).toHaveLength(2)
+  })
+
+  it('does not return other users habits', async () => {
+    const user1 = await createTestUser('user1@test.com')
+    const user2 = await createTestUser('user2@test.com')
+    await prisma.habit.create({ data: { userId: user1.userId, name: 'User1 Habit', position: 0 } })
+    await prisma.habit.create({ data: { userId: user2.userId, name: 'User2 Habit', position: 0 } })
+
+    const res = await request(app)
+      .get('/api/habits')
+      .set('Authorization', `Bearer ${user1.token}`)
+
+    expect(res.body.data).toHaveLength(1)
+    expect(res.body.data[0].name).toBe('User1 Habit')
+  })
+
+  it('filters by category when ?category= is provided', async () => {
+    const { userId, token } = await createTestUser()
+    await prisma.habit.create({ data: { userId, name: 'Run', category: 'Fitness', position: 0 } })
+    await prisma.habit.create({ data: { userId, name: 'Read', category: 'Learning', position: 1 } })
+
+    const res = await request(app)
+      .get('/api/habits?category=Fitness')
+      .set('Authorization', `Bearer ${token}`)
+
+    expect(res.body.data).toHaveLength(1)
+    expect(res.body.data[0].name).toBe('Run')
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).get('/api/habits')
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('PUT /api/habits/:id', () => {
+  it('updates a habit the user owns', async () => {
+    const { userId, token } = await createTestUser()
+    const habit = await prisma.habit.create({ data: { userId, name: 'Old Name', position: 0 } })
+
+    const res = await request(app)
+      .put(`/api/habits/${habit.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'New Name' })
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.name).toBe('New Name')
+  })
+
+  it('returns 403 when updating another users habit', async () => {
+    const user1 = await createTestUser('owner@test.com')
+    const user2 = await createTestUser('other@test.com')
+    const habit = await prisma.habit.create({ data: { userId: user1.userId, name: 'Private', position: 0 } })
+
+    const res = await request(app)
+      .put(`/api/habits/${habit.id}`)
+      .set('Authorization', `Bearer ${user2.token}`)
+      .send({ name: 'Hacked' })
+
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).put('/api/habits/fake-id').send({ name: 'Test' })
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('PATCH /api/habits/:id/archive', () => {
+  it('toggles isArchived false to true', async () => {
+    const { userId, token } = await createTestUser()
+    const habit = await prisma.habit.create({ data: { userId, name: 'Test', position: 0 } })
+
+    const res = await request(app)
+      .patch(`/api/habits/${habit.id}/archive`)
+      .set('Authorization', `Bearer ${token}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.isArchived).toBe(true)
+  })
+
+  it('toggles isArchived true to false', async () => {
+    const { userId, token } = await createTestUser()
+    const habit = await prisma.habit.create({ data: { userId, name: 'Test', position: 0, isArchived: true } })
+
+    const res = await request(app)
+      .patch(`/api/habits/${habit.id}/archive`)
+      .set('Authorization', `Bearer ${token}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.isArchived).toBe(false)
+  })
+
+  it('returns 403 when archiving another users habit', async () => {
+    const user1 = await createTestUser('owner@test.com')
+    const user2 = await createTestUser('other@test.com')
+    const habit = await prisma.habit.create({ data: { userId: user1.userId, name: 'Private', position: 0 } })
+
+    const res = await request(app)
+      .patch(`/api/habits/${habit.id}/archive`)
+      .set('Authorization', `Bearer ${user2.token}`)
+
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).patch('/api/habits/fake-id/archive')
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('PATCH /api/habits/reorder', () => {
+  it('updates positions for habits the user owns', async () => {
+    const { userId, token } = await createTestUser()
+    const h1 = await prisma.habit.create({ data: { userId, name: 'A', position: 0 } })
+    const h2 = await prisma.habit.create({ data: { userId, name: 'B', position: 1 } })
+
+    const res = await request(app)
+      .patch('/api/habits/reorder')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ habits: [{ id: h1.id, position: 1 }, { id: h2.id, position: 0 }] })
+
+    expect(res.status).toBe(200)
+    const updated = await prisma.habit.findMany({ where: { userId }, orderBy: { position: 'asc' } })
+    expect(updated[0].name).toBe('B')
+    expect(updated[1].name).toBe('A')
+  })
+
+  it('returns 403 when reordering another users habits', async () => {
+    const user1 = await createTestUser('owner@test.com')
+    const user2 = await createTestUser('other@test.com')
+    const habit = await prisma.habit.create({ data: { userId: user1.userId, name: 'Private', position: 0 } })
+
+    const res = await request(app)
+      .patch('/api/habits/reorder')
+      .set('Authorization', `Bearer ${user2.token}`)
+      .send({ habits: [{ id: habit.id, position: 5 }] })
+
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).patch('/api/habits/reorder').send({ habits: [] })
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('DELETE /api/habits/:id', () => {
+  it('deletes a habit the user owns', async () => {
+    const { userId, token } = await createTestUser()
+    const habit = await prisma.habit.create({ data: { userId, name: 'ToDelete', position: 0 } })
+
+    const res = await request(app)
+      .delete(`/api/habits/${habit.id}`)
+      .set('Authorization', `Bearer ${token}`)
+
+    expect(res.status).toBe(204)
+    const found = await prisma.habit.findUnique({ where: { id: habit.id } })
+    expect(found).toBeNull()
+  })
+
+  it('returns 403 when deleting another users habit', async () => {
+    const user1 = await createTestUser('owner@test.com')
+    const user2 = await createTestUser('other@test.com')
+    const habit = await prisma.habit.create({ data: { userId: user1.userId, name: 'Private', position: 0 } })
+
+    const res = await request(app)
+      .delete(`/api/habits/${habit.id}`)
+      .set('Authorization', `Bearer ${user2.token}`)
+
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 401 without auth token', async () => {
+    const res = await request(app).delete('/api/habits/fake-id')
+    expect(res.status).toBe(401)
+  })
+})

--- a/server/src/__tests__/helpers.ts
+++ b/server/src/__tests__/helpers.ts
@@ -1,0 +1,26 @@
+import bcrypt from 'bcryptjs'
+import jwt from 'jsonwebtoken'
+import { prisma } from '../lib/prisma.js'
+
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-change-in-production'
+
+export async function createTestUser(
+  email = `test-${Date.now()}@example.com`,
+  name = 'Test User'
+): Promise<{ userId: string; token: string }> {
+  const hashedPassword = await bcrypt.hash('password123', 10)
+
+  const user = await prisma.user.create({
+    data: { email, password: hashedPassword, name },
+  })
+
+  const token = jwt.sign({ userId: user.id }, JWT_SECRET, { expiresIn: '1h' })
+
+  return { userId: user.id, token }
+}
+
+export async function cleanDatabase(): Promise<void> {
+  await prisma.habitLog.deleteMany()
+  await prisma.habit.deleteMany()
+  await prisma.user.deleteMany()
+}

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,6 +1,9 @@
 import express from 'express'
+import type { Request, Response, NextFunction } from 'express'
 import cors from 'cors'
 import { authRoutes } from './routes/auth.js'
+import { authMiddleware } from './middleware/auth.js'
+import habitsRouter from './routes/habits.js'
 
 export function createApp() {
   const app = express()
@@ -13,7 +16,15 @@ export function createApp() {
     res.status(200).json({ status: 'ok', timestamp: new Date().toISOString() })
   })
 
+  // API routes
   app.use('/api/auth', authRoutes)
+  app.use('/api/habits', authMiddleware, habitsRouter)
+
+  // Global error handler
+  app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
+    console.error('Unhandled error:', err)
+    res.status(500).json({ error: 'Internal server error' })
+  })
 
   return app
 }

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -8,6 +8,9 @@ export interface AuthenticatedRequest extends Request {
 const JWT_SECRET =
   process.env.JWT_SECRET || 'dev-secret-change-in-production'
 
+// Alias for route-level usage
+export const authMiddleware = requireAuth
+
 export function requireAuth(
   req: AuthenticatedRequest,
   res: Response,

--- a/server/src/routes/habits.ts
+++ b/server/src/routes/habits.ts
@@ -1,0 +1,214 @@
+import { Router, Request, Response, NextFunction } from 'express'
+import type { IRouter } from 'express'
+import { prisma } from '../lib/prisma.js'
+import type { AuthenticatedRequest } from '../middleware/auth.js'
+import { Frequency } from '@prisma/client'
+
+const router: IRouter = Router()
+
+function asyncHandler(
+  fn: (req: Request, res: Response, next: NextFunction) => Promise<void>
+) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    fn(req, res, next).catch(next)
+  }
+}
+
+function getParam(req: Request, name: string): string {
+  const value = req.params[name]
+  return Array.isArray(value) ? value[0] : value
+}
+
+interface HabitBody {
+  name?: unknown
+  description?: unknown
+  icon?: unknown
+  color?: unknown
+  frequency?: unknown
+  targetDays?: unknown
+  category?: unknown
+}
+
+interface ReorderEntry {
+  id: string
+  position: number
+}
+
+function isValidFrequency(value: unknown): value is Frequency {
+  return value === 'DAILY' || value === 'WEEKLY' || value === 'CUSTOM'
+}
+
+function isValidReorderEntry(value: unknown): value is ReorderEntry {
+  if (typeof value !== 'object' || value === null) return false
+  const entry = value as Record<string, unknown>
+  return (
+    typeof entry.id === 'string' &&
+    (typeof entry.position === 'number' || typeof entry.position === 'string')
+  )
+}
+
+// POST / — create habit
+router.post(
+  '/',
+  asyncHandler(async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    const userId = req.user!.userId
+    const body = req.body as HabitBody
+
+    if (!body.name || typeof body.name !== 'string' || body.name.trim() === '') {
+      res.status(400).json({ error: 'Name is required' })
+      return
+    }
+
+    const frequency =
+      body.frequency !== undefined && isValidFrequency(body.frequency)
+        ? body.frequency
+        : undefined
+
+    const habit = await prisma.habit.create({
+      data: {
+        userId,
+        name: body.name.trim(),
+        description: typeof body.description === 'string' ? body.description : undefined,
+        icon: typeof body.icon === 'string' ? body.icon : undefined,
+        color: typeof body.color === 'string' ? body.color : undefined,
+        frequency,
+        targetDays: typeof body.targetDays === 'number' ? body.targetDays : undefined,
+        category: typeof body.category === 'string' ? body.category : undefined,
+      },
+    })
+
+    res.status(201).json({ data: habit })
+  })
+)
+
+// GET / — list habits for current user
+router.get(
+  '/',
+  asyncHandler(async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    const userId = req.user!.userId
+    const category =
+      typeof req.query.category === 'string' ? req.query.category : undefined
+
+    const habits = await prisma.habit.findMany({
+      where: { userId, ...(category ? { category } : {}) },
+      orderBy: { position: 'asc' },
+    })
+
+    res.status(200).json({ data: habits })
+  })
+)
+
+// PUT /:id — update habit
+router.put(
+  '/:id',
+  asyncHandler(async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    const userId = req.user!.userId
+    const id = getParam(req, 'id')
+    const body = req.body as HabitBody
+
+    const existing = await prisma.habit.findUnique({ where: { id } })
+    if (!existing) { res.status(404).json({ error: 'Habit not found' }); return }
+    if (existing.userId !== userId) { res.status(403).json({ error: 'Forbidden' }); return }
+
+    const frequency =
+      body.frequency !== undefined && isValidFrequency(body.frequency)
+        ? body.frequency
+        : undefined
+
+    const habit = await prisma.habit.update({
+      where: { id },
+      data: {
+        ...(typeof body.name === 'string' ? { name: body.name.trim() } : {}),
+        ...(typeof body.description === 'string' ? { description: body.description } : {}),
+        ...(typeof body.icon === 'string' ? { icon: body.icon } : {}),
+        ...(typeof body.color === 'string' ? { color: body.color } : {}),
+        ...(frequency ? { frequency } : {}),
+        ...(typeof body.targetDays === 'number' ? { targetDays: body.targetDays } : {}),
+        ...(typeof body.category === 'string' ? { category: body.category } : {}),
+      },
+    })
+
+    res.status(200).json({ data: habit })
+  })
+)
+
+// PATCH /reorder — update positions
+router.patch(
+  '/reorder',
+  asyncHandler(async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    const userId = req.user!.userId
+    const body = req.body as { habits?: unknown }
+
+    if (!Array.isArray(body.habits)) {
+      res.status(400).json({ error: 'habits array is required' })
+      return
+    }
+
+    if (body.habits.some((e: unknown) => !isValidReorderEntry(e))) {
+      res.status(400).json({ error: 'Each entry must have a string id and numeric position' })
+      return
+    }
+
+    const entries: ReorderEntry[] = body.habits.map((e: unknown) => ({
+      id: (e as ReorderEntry).id,
+      position: Number((e as ReorderEntry).position),
+    }))
+
+    const ids = entries.map((e) => e.id)
+    const habits = await prisma.habit.findMany({
+      where: { id: { in: ids } },
+      select: { id: true, userId: true },
+    })
+
+    if (habits.some((h) => h.userId !== userId) || habits.length !== ids.length) {
+      res.status(403).json({ error: 'Forbidden' })
+      return
+    }
+
+    await prisma.$transaction(
+      entries.map((entry) =>
+        prisma.habit.update({ where: { id: entry.id }, data: { position: entry.position } })
+      )
+    )
+
+    res.status(200).json({ message: 'Positions updated' })
+  })
+)
+
+// PATCH /:id/archive — toggle archive status
+router.patch(
+  '/:id/archive',
+  asyncHandler(async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    const userId = req.user!.userId
+    const id = getParam(req, 'id')
+
+    const existing = await prisma.habit.findUnique({ where: { id } })
+    if (!existing) { res.status(404).json({ error: 'Habit not found' }); return }
+    if (existing.userId !== userId) { res.status(403).json({ error: 'Forbidden' }); return }
+
+    const habit = await prisma.habit.update({
+      where: { id },
+      data: { isArchived: !existing.isArchived },
+    })
+
+    res.status(200).json({ data: habit })
+  })
+)
+
+// DELETE /:id — delete habit
+router.delete(
+  '/:id',
+  asyncHandler(async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    const userId = req.user!.userId
+    const id = getParam(req, 'id')
+
+    const existing = await prisma.habit.findUnique({ where: { id } })
+    if (!existing) { res.status(404).json({ error: 'Habit not found' }); return }
+    if (existing.userId !== userId) { res.status(403).json({ error: 'Forbidden' }); return }
+
+    await prisma.habit.delete({ where: { id } })
+    res.status(204).send()
+  })
+)
+
+export default router

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -8,5 +8,11 @@ export default defineConfig({
       DATABASE_URL: 'file:./test.db',
       JWT_SECRET: 'test-secret-for-vitest',
     },
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
   },
 })


### PR DESCRIPTION
## Summary
- Full CRUD API for habits (create, list, update, archive, reorder, delete)
- Ownership checks on all mutations (403 for unauthorized access)
- asyncHandler wrapper for proper error forwarding
- Global error handler in app.ts
- Reorder uses Prisma transaction with entry validation
- 20 integration tests

Replaces #20 (rebased cleanly on main after auth merge)

## Test plan
- [x] 32 tests pass (20 habits + 11 auth + 1 health)
- [x] TypeScript compiles clean

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)