### PR TITLE
feat(tracking-ui): add daily checklist with toggle animations

### DIFF
--- a/client/src/__tests__/tracking-store.test.ts
+++ b/client/src/__tests__/tracking-store.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useTrackingStore } from '@/stores/tracking'
+import type { HabitLog } from '@/types/habit'
+
+const mockLogs: HabitLog[] = [
+  {
+    id: 'log-1',
+    habitId: 'habit-1',
+    date: '2024-01-15',
+    completed: true,
+    note: null,
+    createdAt: '2024-01-15T08:00:00.000Z',
+  },
+  {
+    id: 'log-2',
+    habitId: 'habit-2',
+    date: '2024-01-15',
+    completed: true,
+    note: 'Great session!',
+    createdAt: '2024-01-15T09:00:00.000Z',
+  },
+]
+
+describe('useTrackingStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.spyOn(Storage.prototype, 'getItem').mockReturnValue('test-token')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('starts with empty todayLogs map and loading false', () => {
+    const store = useTrackingStore()
+    expect(store.todayLogs.size).toBe(0)
+    expect(store.loading).toBe(false)
+  })
+
+  it('fetchTodayLogs populates todayLogs map keyed by habitId', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: mockLogs }),
+    } as Response)
+
+    const store = useTrackingStore()
+    await store.fetchTodayLogs()
+
+    expect(store.todayLogs.size).toBe(2)
+    expect(store.todayLogs.get('habit-1')).toMatchObject({ id: 'log-1', habitId: 'habit-1' })
+    expect(store.todayLogs.get('habit-2')).toMatchObject({ id: 'log-2', habitId: 'habit-2' })
+  })
+
+  it('fetchTodayLogs passes today date as query param', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: [] }),
+    } as Response)
+
+    const store = useTrackingStore()
+    await store.fetchTodayLogs()
+
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    const calledUrl = fetchMock.mock.calls[0][0] as string
+    const today = new Date().toISOString().slice(0, 10)
+    expect(calledUrl).toContain(`date=${today}`)
+  })
+
+  it('fetchTodayLogs sets loading to false after completion', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: [] }),
+    } as Response)
+
+    const store = useTrackingStore()
+    const fetchPromise = store.fetchTodayLogs()
+    expect(store.loading).toBe(true)
+    await fetchPromise
+    expect(store.loading).toBe(false)
+  })
+
+  it('isCompleted returns true for habits with a log in todayLogs', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: mockLogs }),
+    } as Response)
+
+    const store = useTrackingStore()
+    await store.fetchTodayLogs()
+
+    expect(store.isCompleted('habit-1')).toBe(true)
+    expect(store.isCompleted('habit-2')).toBe(true)
+    expect(store.isCompleted('habit-99')).toBe(false)
+  })
+
+  it('toggleHabit adds log to todayLogs when completed is true', async () => {
+    const newLog: HabitLog = {
+      id: 'log-3',
+      habitId: 'habit-3',
+      date: '2024-01-15',
+      completed: true,
+      note: null,
+      createdAt: '2024-01-15T10:00:00.000Z',
+    }
+
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: newLog }),
+    } as Response)
+
+    const store = useTrackingStore()
+    expect(store.isCompleted('habit-3')).toBe(false)
+
+    await store.toggleHabit('habit-3')
+
+    expect(store.isCompleted('habit-3')).toBe(true)
+    expect(store.todayLogs.get('habit-3')).toMatchObject({ id: 'log-3' })
+  })
+
+  it('toggleHabit removes log from todayLogs when completed is false (untoggle)', async () => {
+    const store = useTrackingStore()
+    // Pre-populate with a log
+    store.todayLogs.set('habit-1', mockLogs[0])
+
+    const untoggledLog: HabitLog = {
+      ...mockLogs[0],
+      completed: false,
+    }
+
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: untoggledLog }),
+    } as Response)
+
+    expect(store.isCompleted('habit-1')).toBe(true)
+
+    await store.toggleHabit('habit-1')
+
+    expect(store.isCompleted('habit-1')).toBe(false)
+  })
+
+  it('toggleHabit calls POST /api/tracking/:id/toggle with auth header', async () => {
+    const newLog: HabitLog = {
+      id: 'log-4',
+      habitId: 'habit-4',
+      date: '2024-01-15',
+      completed: true,
+      note: null,
+      createdAt: '2024-01-15T11:00:00.000Z',
+    }
+
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: newLog }),
+    } as Response)
+
+    const store = useTrackingStore()
+    await store.toggleHabit('habit-4')
+
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    const [calledUrl, calledOptions] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(calledUrl).toContain('/api/tracking/habit-4/toggle')
+    expect(calledOptions.method).toBe('POST')
+    expect((calledOptions.headers as Record<string, string>)['Authorization']).toBe(
+      'Bearer test-token',
+    )
+  })
+})

--- a/client/src/__tests__/tracking-store.test.ts
+++ b/client/src/__tests__/tracking-store.test.ts
@@ -106,7 +106,7 @@ describe('useTrackingStore', () => {
 
     global.fetch = vi.fn().mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ data: newLog }),
+      json: async () => ({ data: { completed: true, log: newLog } }),
     } as Response)
 
     const store = useTrackingStore()
@@ -123,14 +123,9 @@ describe('useTrackingStore', () => {
     // Pre-populate with a log
     store.todayLogs.set('habit-1', mockLogs[0])
 
-    const untoggledLog: HabitLog = {
-      ...mockLogs[0],
-      completed: false,
-    }
-
     global.fetch = vi.fn().mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ data: untoggledLog }),
+      json: async () => ({ data: { completed: false, log: null } }),
     } as Response)
 
     expect(store.isCompleted('habit-1')).toBe(true)
@@ -152,7 +147,7 @@ describe('useTrackingStore', () => {
 
     global.fetch = vi.fn().mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ data: newLog }),
+      json: async () => ({ data: { completed: true, log: newLog } }),
     } as Response)
 
     const store = useTrackingStore()
@@ -165,5 +160,70 @@ describe('useTrackingStore', () => {
     expect((calledOptions.headers as Record<string, string>)['Authorization']).toBe(
       'Bearer test-token',
     )
+  })
+
+  it('toggleHabit applies optimistic update immediately before fetch resolves', async () => {
+    let resolveFetch!: (value: unknown) => void
+    const fetchPromise = new Promise((resolve) => { resolveFetch = resolve })
+
+    global.fetch = vi.fn().mockReturnValueOnce(fetchPromise)
+
+    const store = useTrackingStore()
+    expect(store.isCompleted('habit-5')).toBe(false)
+
+    const togglePromise = store.toggleHabit('habit-5')
+
+    // Before fetch resolves, the optimistic update should already be applied
+    expect(store.isCompleted('habit-5')).toBe(true)
+    expect(store.todayLogs.get('habit-5')).toMatchObject({ id: 'temp', habitId: 'habit-5' })
+
+    // Now resolve the fetch with real server data
+    const realLog: HabitLog = {
+      id: 'log-5',
+      habitId: 'habit-5',
+      date: '2024-01-15',
+      completed: true,
+      note: null,
+      createdAt: '2024-01-15T12:00:00.000Z',
+    }
+    resolveFetch({ ok: true, json: async () => ({ data: { completed: true, log: realLog } }) })
+    await togglePromise
+
+    // After fetch, the real log replaces the optimistic one
+    expect(store.isCompleted('habit-5')).toBe(true)
+    expect(store.todayLogs.get('habit-5')).toMatchObject({ id: 'log-5' })
+  })
+
+  it('toggleHabit rolls back optimistic update on fetch error', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Server error' }),
+    } as Response)
+
+    const store = useTrackingStore()
+    expect(store.isCompleted('habit-6')).toBe(false)
+
+    await store.toggleHabit('habit-6')
+
+    // Should be rolled back to the original state (not completed)
+    expect(store.isCompleted('habit-6')).toBe(false)
+  })
+
+  it('toggleHabit rolls back to previous log on error when habit was already completed', async () => {
+    const store = useTrackingStore()
+    store.todayLogs.set('habit-1', mockLogs[0])
+
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Server error' }),
+    } as Response)
+
+    expect(store.isCompleted('habit-1')).toBe(true)
+
+    await store.toggleHabit('habit-1')
+
+    // Should be rolled back to completed (the previous state)
+    expect(store.isCompleted('habit-1')).toBe(true)
+    expect(store.todayLogs.get('habit-1')).toMatchObject({ id: 'log-1' })
   })
 })

--- a/client/src/components/tracking/HabitCheckItem.vue
+++ b/client/src/components/tracking/HabitCheckItem.vue
@@ -1,0 +1,156 @@
+<script setup lang="ts">
+import type { Habit } from '@/types/habit'
+
+const props = defineProps<{
+  habit: Habit
+  checked: boolean
+}>()
+
+const emit = defineEmits<{
+  toggle: []
+}>()
+
+function handleToggle() {
+  emit('toggle')
+}
+</script>
+
+<template>
+  <div class="habit-item" :class="{ 'habit-item--checked': props.checked }" @click="handleToggle">
+    <!-- Icon circle -->
+    <div
+      class="habit-icon"
+      :style="{ backgroundColor: props.habit.color + '33', borderColor: props.habit.color + '55' }"
+    >
+      <span class="habit-icon__emoji">{{ props.habit.icon }}</span>
+    </div>
+
+    <!-- Name + streak -->
+    <div class="habit-info">
+      <span class="habit-name" :class="{ 'habit-name--done': props.checked }">
+        {{ props.habit.name }}
+      </span>
+      <span class="habit-streak">{{ props.habit.targetDays }} day streak goal</span>
+    </div>
+
+    <!-- Checkbox -->
+    <div class="habit-checkbox" :class="{ 'habit-checkbox--checked': props.checked }">
+      <svg
+        v-if="props.checked"
+        width="14"
+        height="14"
+        viewBox="0 0 14 14"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <path
+          d="M2 7L5.5 10.5L12 4"
+          stroke="white"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.habit-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+  user-select: none;
+}
+
+.habit-item:hover {
+  background: var(--surface-alt);
+}
+
+.habit-icon {
+  width: 40px;
+  height: 40px;
+  min-width: 40px;
+  border-radius: 50%;
+  border: 1.5px solid transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.habit-icon__emoji {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.habit-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.habit-name {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+  transition:
+    opacity 0.2s ease,
+    text-decoration 0.2s ease;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.habit-name--done {
+  text-decoration: line-through;
+  opacity: 0.5;
+}
+
+.habit-streak {
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.habit-checkbox {
+  width: 28px;
+  height: 28px;
+  min-width: 28px;
+  border-radius: 50%;
+  border: 2px solid var(--border);
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.habit-checkbox--checked {
+  background: var(--accent);
+  border-color: var(--accent);
+  animation: bounce-check 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+@keyframes bounce-check {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.15);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+</style>

--- a/client/src/components/tracking/TodayChecklist.vue
+++ b/client/src/components/tracking/TodayChecklist.vue
@@ -1,0 +1,115 @@
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { useHabitsStore } from '@/stores/habits'
+import { useTrackingStore } from '@/stores/tracking'
+import HabitCheckItem from './HabitCheckItem.vue'
+
+const habitsStore = useHabitsStore()
+const trackingStore = useTrackingStore()
+
+const activeHabits = computed(() => habitsStore.habits.filter((h) => !h.isArchived))
+
+const doneCount = computed(
+  () => activeHabits.value.filter((h) => trackingStore.isCompleted(h.id)).length,
+)
+
+const totalCount = computed(() => activeHabits.value.length)
+
+async function handleToggle(habitId: string) {
+  await trackingStore.toggleHabit(habitId)
+}
+
+onMounted(async () => {
+  await Promise.all([habitsStore.fetchHabits(), trackingStore.fetchTodayLogs()])
+})
+</script>
+
+<template>
+  <div class="checklist">
+    <!-- Header -->
+    <div class="checklist__header">
+      <h2 class="checklist__title">Today's Habits</h2>
+      <span class="checklist__counter">
+        {{ doneCount }}<span class="checklist__counter-total">/{{ totalCount }} done</span>
+      </span>
+    </div>
+
+    <!-- Loading state -->
+    <div v-if="trackingStore.loading || habitsStore.loading" class="checklist__loading">
+      <span>Loading…</span>
+    </div>
+
+    <!-- Empty state -->
+    <div v-else-if="activeHabits.length === 0" class="checklist__empty">
+      <p>No habits yet. Add your first habit to get started!</p>
+    </div>
+
+    <!-- Habit list -->
+    <ul v-else class="checklist__list" role="list">
+      <li v-for="habit in activeHabits" :key="habit.id" class="checklist__list-item">
+        <HabitCheckItem
+          :habit="habit"
+          :checked="trackingStore.isCompleted(habit.id)"
+          @toggle="handleToggle(habit.id)"
+        />
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.checklist {
+  background: var(--surface);
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  box-shadow: 0 4px 24px rgba(45, 43, 61, 0.06);
+  padding: 20px 8px 12px;
+}
+
+.checklist__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 16px 16px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 8px;
+}
+
+.checklist__title {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.checklist__counter {
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.checklist__counter-total {
+  font-weight: 400;
+  color: var(--text-muted);
+}
+
+.checklist__loading,
+.checklist__empty {
+  padding: 24px 16px;
+  text-align: center;
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+.checklist__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.checklist__list-item {
+  display: block;
+}
+</style>

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -31,6 +31,12 @@ const router = createRouter({
       name: 'habits',
       component: () => import('../views/HabitsView.vue'),
     },
+    {
+      path: '/today',
+      name: 'today',
+      component: () => import('../views/TodayView.vue'),
+      meta: { requiresAuth: true },
+    },
   ],
 })
 

--- a/client/src/stores/tracking.ts
+++ b/client/src/stores/tracking.ts
@@ -1,0 +1,81 @@
+import { ref, computed } from 'vue'
+import { defineStore } from 'pinia'
+import type { HabitLog } from '@/types/habit'
+
+const API_BASE = `${import.meta.env.VITE_API_URL || 'http://localhost:3001'}/api`
+
+function getToken(): string {
+  return localStorage.getItem('token') ?? ''
+}
+
+function authHeaders(): HeadersInit {
+  return {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${getToken()}`,
+  }
+}
+
+function todayDateString(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+async function parseResponse<T>(res: Response): Promise<T> {
+  const json: unknown = await res.json()
+  if (!res.ok) {
+    const message =
+      typeof json === 'object' && json !== null && 'message' in json
+        ? String((json as Record<string, unknown>).message)
+        : `HTTP error ${res.status}`
+    throw new Error(message)
+  }
+  const envelope = json as { data?: T }
+  return (envelope.data ?? json) as T
+}
+
+export const useTrackingStore = defineStore('tracking', () => {
+  const todayLogs = ref<Map<string, HabitLog>>(new Map())
+  const loading = ref(false)
+
+  async function fetchTodayLogs(): Promise<void> {
+    loading.value = true
+    try {
+      const date = todayDateString()
+      const url = `${API_BASE}/tracking/logs?date=${date}`
+      const res = await fetch(url, { headers: authHeaders() })
+      const logs = await parseResponse<HabitLog[]>(res)
+      const map = new Map<string, HabitLog>()
+      for (const log of logs) {
+        map.set(log.habitId, log)
+      }
+      todayLogs.value = map
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function toggleHabit(habitId: string): Promise<void> {
+    const url = `${API_BASE}/tracking/${habitId}/toggle`
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: authHeaders(),
+    })
+    const log = await parseResponse<HabitLog>(res)
+    if (log.completed) {
+      todayLogs.value = new Map(todayLogs.value).set(log.habitId, log)
+    } else {
+      const updated = new Map(todayLogs.value)
+      updated.delete(log.habitId)
+      todayLogs.value = updated
+    }
+  }
+
+  const isCompleted = computed(() => (habitId: string) => todayLogs.value.has(habitId))
+
+  return {
+    todayLogs,
+    loading,
+    fetchTodayLogs,
+    toggleHabit,
+    isCompleted,
+  }
+})

--- a/client/src/stores/tracking.ts
+++ b/client/src/stores/tracking.ts
@@ -54,18 +54,46 @@ export const useTrackingStore = defineStore('tracking', () => {
   }
 
   async function toggleHabit(habitId: string): Promise<void> {
-    const url = `${API_BASE}/tracking/${habitId}/toggle`
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: authHeaders(),
-    })
-    const log = await parseResponse<HabitLog>(res)
-    if (log.completed) {
-      todayLogs.value = new Map(todayLogs.value).set(log.habitId, log)
+    const wasCompleted = todayLogs.value.has(habitId)
+    const previousLog = todayLogs.value.get(habitId)
+
+    // Optimistic update — reflect change immediately before server responds
+    if (wasCompleted) {
+      todayLogs.value.delete(habitId)
     } else {
-      const updated = new Map(todayLogs.value)
-      updated.delete(log.habitId)
-      todayLogs.value = updated
+      todayLogs.value.set(habitId, {
+        id: 'temp',
+        habitId,
+        date: new Date().toISOString(),
+        completed: true,
+        note: null,
+        createdAt: new Date().toISOString(),
+      })
+    }
+
+    try {
+      const url = `${API_BASE}/tracking/${habitId}/toggle`
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: authHeaders(),
+      })
+      if (!res.ok) throw new Error('Toggle failed')
+      const json = (await res.json()) as { data: { completed: boolean; log: HabitLog | null } }
+      const { completed, log } = json.data
+
+      // Replace optimistic value with real server data
+      if (completed && log) {
+        todayLogs.value.set(habitId, log)
+      } else {
+        todayLogs.value.delete(habitId)
+      }
+    } catch {
+      // Rollback optimistic update on error
+      if (wasCompleted && previousLog) {
+        todayLogs.value.set(habitId, previousLog)
+      } else {
+        todayLogs.value.delete(habitId)
+      }
     }
   }
 

--- a/client/src/types/habit.ts
+++ b/client/src/types/habit.ts
@@ -24,3 +24,12 @@ export interface CreateHabitData {
 }
 
 export type UpdateHabitData = Partial<CreateHabitData & { isArchived: boolean; position: number }>
+
+export interface HabitLog {
+  id: string
+  habitId: string
+  date: string
+  completed: boolean
+  note: string | null
+  createdAt: string
+}

--- a/client/src/views/TodayView.vue
+++ b/client/src/views/TodayView.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import TodayChecklist from '@/components/tracking/TodayChecklist.vue'
+
+const today = new Date().toLocaleDateString('en-US', {
+  weekday: 'long',
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+})
+</script>
+
+<template>
+  <div class="today-page">
+    <div class="today-container">
+      <!-- Page header -->
+      <div class="today-header">
+        <h1 class="today-header__title">Today</h1>
+        <p class="today-header__date">{{ today }}</p>
+      </div>
+
+      <!-- Checklist -->
+      <TodayChecklist />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.today-page {
+  min-height: 100vh;
+  background: var(--bg);
+  padding: 32px 16px;
+}
+
+.today-container {
+  max-width: 600px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.today-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.today-header__title {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 32px;
+  font-weight: 800;
+  color: var(--text);
+}
+
+.today-header__date {
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  color: var(--text-muted);
+}
+</style>


### PR DESCRIPTION
## Summary

- Adds `HabitLog` type to `client/src/types/habit.ts`
- Creates Pinia tracking store (`stores/tracking.ts`) with `fetchTodayLogs`, `toggleHabit`, and `isCompleted` computed
- Implements `HabitCheckItem.vue` (emoji icon circle, habit name with strikethrough/opacity on done, animated 28px checkbox with bounce)
- Implements `TodayChecklist.vue` (X/Y done counter, list of habit check items, loading/empty states)
- Adds `TodayView.vue` page with date header
- Registers `/today` route (requiresAuth) in Vue Router
- Adds `client/src/__tests__/tracking-store.test.ts` with 7 tests covering fetchTodayLogs, toggleHabit, and isCompleted

## Test plan

- [x] All 29 client tests pass (`pnpm test:client`)
- [ ] Navigate to `/today` — should see today's date and habit checklist
- [ ] Click a habit row — checkbox bounces, turns mint green, name gets line-through
- [ ] Click again — checkbox empties, name restores
- [ ] Counter updates as habits are toggled

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Today" page with a daily habit checklist.
  * Users can view all active habits for the current day and toggle their completion status.
  * Real-time progress display shows how many habits have been completed.
  * Includes loading and empty-state messaging for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->