### PR TITLE
feat(stats): add stats API and dashboard widgets

### DIFF
--- a/client/src/__tests__/stats-store.test.ts
+++ b/client/src/__tests__/stats-store.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useStatsStore } from '@/stores/stats'
+import type { Stats } from '@/types/stats'
+
+const mockStats: Stats = {
+  today: {
+    completed: 5,
+    total: 8,
+    rate: 0.625,
+  },
+  streaks: {
+    best: { habitId: 'h1', habitName: 'Morning Run', count: 25 },
+    current: [
+      { habitId: 'h1', habitName: 'Morning Run', count: 12 },
+      { habitId: 'h2', habitName: 'Read', count: 5 },
+    ],
+  },
+  thisMonth: {
+    completions: 142,
+    previousMonth: 120,
+  },
+  activeHabits: 8,
+  categoryBreakdown: [
+    { category: 'Health', count: 3, percentage: 0.375 },
+    { category: 'Learning', count: 2, percentage: 0.25 },
+  ],
+  weeklyHeatmap: [
+    { habitId: 'h1', habitName: 'Morning Run', days: [true, true, false, true, true, true, false] },
+  ],
+}
+
+describe('useStatsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.spyOn(Storage.prototype, 'getItem').mockReturnValue('test-token')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('starts with null stats and loading false', () => {
+    const store = useStatsStore()
+    expect(store.stats).toBeNull()
+    expect(store.loading).toBe(false)
+  })
+
+  it('fetchStats populates the store with stats from the API', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: mockStats }),
+    } as Response)
+
+    const store = useStatsStore()
+    await store.fetchStats()
+
+    expect(store.stats).not.toBeNull()
+    expect(store.stats!.today.completed).toBe(5)
+    expect(store.stats!.today.total).toBe(8)
+    expect(store.stats!.today.rate).toBe(0.625)
+  })
+
+  it('fetchStats sets loading to false after completion', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: mockStats }),
+    } as Response)
+
+    const store = useStatsStore()
+    const fetchPromise = store.fetchStats()
+    expect(store.loading).toBe(true)
+    await fetchPromise
+    expect(store.loading).toBe(false)
+  })
+
+  it('fetchStats sends Authorization header with Bearer token', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: mockStats }),
+    } as Response)
+
+    const store = useStatsStore()
+    await store.fetchStats()
+
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
+    const calledOptions = fetchMock.mock.calls[0][1] as RequestInit
+    const headers = calledOptions.headers as Record<string, string>
+    expect(headers['Authorization']).toBe('Bearer test-token')
+  })
+
+  it('fetchStats throws and sets loading false on API error', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: 'Unauthorized' }),
+    } as Response)
+
+    const store = useStatsStore()
+    await expect(store.fetchStats()).rejects.toThrow('Unauthorized')
+    expect(store.loading).toBe(false)
+  })
+
+  it('fetched stats include streaks and categoryBreakdown', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: mockStats }),
+    } as Response)
+
+    const store = useStatsStore()
+    await store.fetchStats()
+
+    expect(store.stats!.streaks.best.count).toBe(25)
+    expect(store.stats!.streaks.current).toHaveLength(2)
+    expect(store.stats!.categoryBreakdown).toHaveLength(2)
+    expect(store.stats!.categoryBreakdown[0].category).toBe('Health')
+    expect(store.stats!.weeklyHeatmap).toHaveLength(1)
+    expect(store.stats!.weeklyHeatmap[0].days).toHaveLength(7)
+  })
+
+  it('fetchStats sets activeHabits correctly', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: mockStats }),
+    } as Response)
+
+    const store = useStatsStore()
+    await store.fetchStats()
+
+    expect(store.stats!.activeHabits).toBe(8)
+  })
+})

--- a/client/src/components/dashboard/CategoryDonut.vue
+++ b/client/src/components/dashboard/CategoryDonut.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { CategoryData } from '@/types/stats'
+
+interface Props {
+  data: CategoryData[]
+}
+
+const props = defineProps<Props>()
+
+const COLORS = [
+  'var(--primary)',
+  'var(--secondary)',
+  'var(--accent)',
+  'var(--warning)',
+  'var(--primary-light)',
+  'var(--secondary-light)',
+  'var(--accent-light)',
+  'var(--warning-light)',
+]
+
+const SIZE = 120
+const STROKE_WIDTH = 28
+const RADIUS = (SIZE - STROKE_WIDTH) / 2
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS
+const CENTER = SIZE / 2
+
+interface Segment {
+  category: string
+  color: string
+  dasharray: string
+  dashoffset: number
+  percentage: number
+  count: number
+}
+
+const segments = computed<Segment[]>(() => {
+  let cumulativeOffset = 0
+  // Start from the top (rotate -90 degrees applied via transform on SVG)
+  return props.data.map((item, idx) => {
+    const arc = item.percentage * CIRCUMFERENCE
+    const offset = CIRCUMFERENCE - cumulativeOffset
+    cumulativeOffset += arc
+    return {
+      category: item.category,
+      color: COLORS[idx % COLORS.length],
+      dasharray: `${arc} ${CIRCUMFERENCE - arc}`,
+      dashoffset: offset,
+      percentage: item.percentage,
+      count: item.count,
+    }
+  })
+})
+</script>
+
+<template>
+  <div class="donut">
+    <svg
+      :width="SIZE"
+      :height="SIZE"
+      :viewBox="`0 0 ${SIZE} ${SIZE}`"
+      class="donut__svg"
+    >
+      <!-- Background track -->
+      <circle
+        :cx="CENTER"
+        :cy="CENTER"
+        :r="RADIUS"
+        fill="none"
+        :stroke="'var(--border)'"
+        :stroke-width="STROKE_WIDTH"
+      />
+
+      <!-- Segments -->
+      <circle
+        v-for="(seg, idx) in segments"
+        :key="idx"
+        :cx="CENTER"
+        :cy="CENTER"
+        :r="RADIUS"
+        fill="none"
+        :stroke="seg.color"
+        :stroke-width="STROKE_WIDTH"
+        :stroke-dasharray="seg.dasharray"
+        :stroke-dashoffset="seg.dashoffset"
+        transform="rotate(-90)"
+        :transform-origin="`${CENTER} ${CENTER}`"
+      />
+    </svg>
+
+    <!-- Legend -->
+    <div class="donut__legend">
+      <div
+        v-for="(seg, idx) in segments"
+        :key="idx"
+        class="donut__legend-item"
+      >
+        <span
+          class="donut__legend-dot"
+          :style="{ background: seg.color }"
+        />
+        <span class="donut__legend-name">{{ seg.category }}</span>
+        <span class="donut__legend-pct">{{ Math.round(seg.percentage * 100) }}%</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.donut {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.donut__svg {
+  flex-shrink: 0;
+}
+
+.donut__legend {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.donut__legend-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.donut__legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.donut__legend-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  flex: 1;
+}
+
+.donut__legend-pct {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+</style>

--- a/client/src/components/dashboard/CompletionCircle.vue
+++ b/client/src/components/dashboard/CompletionCircle.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+import { ref, onMounted, computed } from 'vue'
+
+interface Props {
+  percentage: number
+}
+
+const props = defineProps<Props>()
+
+const SIZE = 140
+const STROKE_WIDTH = 8
+const RADIUS = (SIZE - STROKE_WIDTH) / 2
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS
+
+const animatedPercentage = ref(0)
+
+const dashoffset = computed(() => {
+  const clipped = Math.min(1, Math.max(0, animatedPercentage.value))
+  return CIRCUMFERENCE * (1 - clipped)
+})
+
+const displayPercent = computed(() => Math.round(props.percentage * 100))
+
+onMounted(() => {
+  // Animate from 0 to target over 600ms ease-out
+  const target = props.percentage
+  const start = performance.now()
+  const duration = 600
+
+  function easeOut(t: number): number {
+    return 1 - Math.pow(1 - t, 3)
+  }
+
+  function step(now: number) {
+    const elapsed = now - start
+    const t = Math.min(elapsed / duration, 1)
+    animatedPercentage.value = easeOut(t) * target
+    if (t < 1) requestAnimationFrame(step)
+  }
+
+  requestAnimationFrame(step)
+})
+</script>
+
+<template>
+  <div class="completion-circle">
+    <svg :width="SIZE" :height="SIZE" :viewBox="`0 0 ${SIZE} ${SIZE}`">
+      <defs>
+        <linearGradient id="completion-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stop-color="var(--primary)" />
+          <stop offset="100%" stop-color="var(--secondary)" />
+        </linearGradient>
+      </defs>
+
+      <!-- Track -->
+      <circle
+        :cx="SIZE / 2"
+        :cy="SIZE / 2"
+        :r="RADIUS"
+        fill="none"
+        :stroke="'var(--border)'"
+        :stroke-width="STROKE_WIDTH"
+      />
+
+      <!-- Fill -->
+      <circle
+        :cx="SIZE / 2"
+        :cy="SIZE / 2"
+        :r="RADIUS"
+        fill="none"
+        stroke="url(#completion-gradient)"
+        :stroke-width="STROKE_WIDTH"
+        stroke-linecap="round"
+        :stroke-dasharray="CIRCUMFERENCE"
+        :stroke-dashoffset="dashoffset"
+        transform="rotate(-90)"
+        :transform-origin="`${SIZE / 2} ${SIZE / 2}`"
+      />
+    </svg>
+
+    <div class="completion-circle__text">
+      <span class="completion-circle__percent">{{ displayPercent }}%</span>
+      <span class="completion-circle__label">complete</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.completion-circle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 140px;
+  height: 140px;
+}
+
+.completion-circle__text {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+}
+
+.completion-circle__percent {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1;
+}
+
+.completion-circle__label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+</style>

--- a/client/src/components/dashboard/KpiCard.vue
+++ b/client/src/components/dashboard/KpiCard.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+interface Props {
+  value: string | number
+  label: string
+  trend?: string
+}
+
+defineProps<Props>()
+</script>
+
+<template>
+  <div class="kpi-card">
+    <div class="kpi-card__value">{{ value }}</div>
+    <div class="kpi-card__label">{{ label }}</div>
+    <div v-if="trend" class="kpi-card__trend">
+      <span class="kpi-card__trend-arrow">
+        {{ trend.startsWith('-') ? '↓' : '↑' }}
+      </span>
+      {{ trend }}
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.kpi-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  padding: 20px;
+  background: var(--surface);
+  border-radius: 16px;
+}
+
+.kpi-card__value {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 40px;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1;
+}
+
+.kpi-card__label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.kpi-card__trend {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--accent);
+  margin-top: 4px;
+}
+
+.kpi-card__trend-arrow {
+  font-size: 14px;
+}
+</style>

--- a/client/src/components/dashboard/StreakCard.vue
+++ b/client/src/components/dashboard/StreakCard.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+interface Props {
+  count: number
+  habitName: string
+  trend?: string
+}
+
+defineProps<Props>()
+</script>
+
+<template>
+  <div class="streak-card">
+    <div class="streak-card__flame">🔥</div>
+    <div class="streak-card__count">{{ count }}</div>
+    <div class="streak-card__suffix">day streak</div>
+    <div class="streak-card__name">{{ habitName }}</div>
+    <div v-if="trend" class="streak-card__trend">
+      <span class="streak-card__trend-arrow">{{ trend.startsWith('-') ? '↓' : '↑' }}</span>
+      <span>{{ trend }}</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.streak-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 20px 16px;
+  background: var(--surface);
+  border-radius: 16px;
+  text-align: center;
+}
+
+.streak-card__flame {
+  font-size: 32px;
+  line-height: 1;
+}
+
+.streak-card__count {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 40px;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1;
+}
+
+.streak-card__suffix {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.streak-card__name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-top: 4px;
+  max-width: 160px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.streak-card__trend {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 13px;
+  color: var(--accent);
+  font-weight: 500;
+  margin-top: 4px;
+}
+
+.streak-card__trend-arrow {
+  font-size: 14px;
+}
+</style>

--- a/client/src/components/dashboard/WeeklyHeatmap.vue
+++ b/client/src/components/dashboard/WeeklyHeatmap.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+import type { HeatmapData } from '@/types/stats'
+
+interface Props {
+  data: HeatmapData[]
+}
+
+defineProps<Props>()
+
+const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+
+function cellClass(completed: boolean): string {
+  return completed ? 'heatmap__cell heatmap__cell--done' : 'heatmap__cell heatmap__cell--empty'
+}
+</script>
+
+<template>
+  <div class="heatmap">
+    <!-- Day labels header -->
+    <div class="heatmap__row heatmap__row--header">
+      <div class="heatmap__habit-label" />
+      <div
+        v-for="day in DAY_LABELS"
+        :key="day"
+        class="heatmap__day-label"
+      >
+        {{ day }}
+      </div>
+    </div>
+
+    <!-- Habit rows -->
+    <div
+      v-for="item in data"
+      :key="item.habitId"
+      class="heatmap__row"
+    >
+      <div class="heatmap__habit-label" :title="item.habitName">
+        {{ item.habitName }}
+      </div>
+      <div
+        v-for="(completed, idx) in item.days"
+        :key="idx"
+        :class="cellClass(completed)"
+        :title="completed ? 'Completed' : 'Not completed'"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.heatmap {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  overflow-x: auto;
+}
+
+.heatmap__row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.heatmap__row--header {
+  margin-bottom: 2px;
+}
+
+.heatmap__habit-label {
+  width: 80px;
+  min-width: 80px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-right: 8px;
+}
+
+.heatmap__day-label {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.heatmap__cell {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  flex-shrink: 0;
+  transition: transform 0.1s ease;
+  cursor: default;
+}
+
+.heatmap__cell:hover {
+  transform: scale(1.15);
+}
+
+.heatmap__cell--empty {
+  background-color: var(--accent-light);
+  opacity: 0.3;
+}
+
+.heatmap__cell--done {
+  background-color: var(--accent);
+}
+</style>

--- a/client/src/stores/stats.ts
+++ b/client/src/stores/stats.ts
@@ -1,0 +1,46 @@
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+import type { Stats } from '@/types/stats'
+
+const API_BASE = `${import.meta.env.VITE_API_URL || 'http://localhost:3001'}/api/stats`
+
+function getToken(): string {
+  return localStorage.getItem('token') ?? ''
+}
+
+function authHeaders(): HeadersInit {
+  return {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${getToken()}`,
+  }
+}
+
+export const useStatsStore = defineStore('stats', () => {
+  const stats = ref<Stats | null>(null)
+  const loading = ref(false)
+
+  async function fetchStats(): Promise<void> {
+    loading.value = true
+    try {
+      const res = await fetch(API_BASE, { headers: authHeaders() })
+      if (!res.ok) {
+        const json: unknown = await res.json().catch(() => ({}))
+        const message =
+          typeof json === 'object' && json !== null && 'error' in json
+            ? String((json as Record<string, unknown>).error)
+            : `HTTP error ${res.status}`
+        throw new Error(message)
+      }
+      const json = (await res.json()) as { data: Stats }
+      stats.value = json.data
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    stats,
+    loading,
+    fetchStats,
+  }
+})

--- a/client/src/types/stats.ts
+++ b/client/src/types/stats.ts
@@ -1,0 +1,48 @@
+export interface TodayStats {
+  completed: number
+  total: number
+  rate: number
+}
+
+export interface BestStreak {
+  habitId: string
+  habitName: string
+  count: number
+}
+
+export interface CurrentStreak {
+  habitId: string
+  habitName: string
+  count: number
+}
+
+export interface Streaks {
+  best: BestStreak
+  current: CurrentStreak[]
+}
+
+export interface ThisMonthStats {
+  completions: number
+  previousMonth: number
+}
+
+export interface CategoryData {
+  category: string
+  count: number
+  percentage: number
+}
+
+export interface HeatmapData {
+  habitId: string
+  habitName: string
+  days: boolean[]
+}
+
+export interface Stats {
+  today: TodayStats
+  streaks: Streaks
+  thisMonth: ThisMonthStats
+  activeHabits: number
+  categoryBreakdown: CategoryData[]
+  weeklyHeatmap: HeatmapData[]
+}

--- a/server/src/__tests__/stats.test.ts
+++ b/server/src/__tests__/stats.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import request from 'supertest'
+import { createApp } from '../app.js'
+import { createTestUser, cleanDatabase } from './helpers.js'
+import { prisma } from '../lib/prisma.js'
+
+const app = createApp()
+
+beforeEach(async () => {
+  await cleanDatabase()
+})
+
+describe('GET /api/stats', () => {
+  it('returns 401 without token', async () => {
+    const res = await request(app).get('/api/stats')
+    expect(res.status).toBe(401)
+  })
+
+  it('returns stats object with expected shape', async () => {
+    const { token } = await createTestUser()
+
+    const res = await request(app)
+      .get('/api/stats')
+      .set('Authorization', `Bearer ${token}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.data).toBeDefined()
+
+    const { data } = res.body
+
+    // today
+    expect(data.today).toBeDefined()
+    expect(typeof data.today.completed).toBe('number')
+    expect(typeof data.today.total).toBe('number')
+    expect(typeof data.today.rate).toBe('number')
+
+    // streaks
+    expect(data.streaks).toBeDefined()
+    expect(data.streaks.best).toBeDefined()
+    expect(typeof data.streaks.best.count).toBe('number')
+    expect(Array.isArray(data.streaks.current)).toBe(true)
+
+    // thisMonth
+    expect(data.thisMonth).toBeDefined()
+    expect(typeof data.thisMonth.completions).toBe('number')
+    expect(typeof data.thisMonth.previousMonth).toBe('number')
+
+    // activeHabits
+    expect(typeof data.activeHabits).toBe('number')
+
+    // categoryBreakdown
+    expect(Array.isArray(data.categoryBreakdown)).toBe(true)
+
+    // weeklyHeatmap
+    expect(Array.isArray(data.weeklyHeatmap)).toBe(true)
+  })
+
+  it('today stats reflect actual completed logs', async () => {
+    const { userId, token } = await createTestUser()
+
+    // Create 3 habits
+    const h1 = await prisma.habit.create({ data: { userId, name: 'Run', position: 0 } })
+    const h2 = await prisma.habit.create({ data: { userId, name: 'Read', position: 1 } })
+    await prisma.habit.create({ data: { userId, name: 'Meditate', position: 2 } })
+
+    // Log 2 of the 3 habits today
+    const today = new Date()
+    today.setUTCHours(0, 0, 0, 0)
+    await prisma.habitLog.create({ data: { habitId: h1.id, date: today, completed: true } })
+    await prisma.habitLog.create({ data: { habitId: h2.id, date: today, completed: true } })
+
+    const res = await request(app)
+      .get('/api/stats')
+      .set('Authorization', `Bearer ${token}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.today.completed).toBe(2)
+    expect(res.body.data.today.total).toBe(3)
+    expect(res.body.data.today.rate).toBeCloseTo(2 / 3)
+  })
+
+  it('streaks reflect consecutive log data', async () => {
+    const { userId, token } = await createTestUser()
+    const habit = await prisma.habit.create({ data: { userId, name: 'Exercise', position: 0 } })
+
+    // Create 5 consecutive days ending today
+    const today = new Date()
+    today.setUTCHours(0, 0, 0, 0)
+    for (let i = 4; i >= 0; i--) {
+      const d = new Date(today)
+      d.setUTCDate(d.getUTCDate() - i)
+      await prisma.habitLog.create({ data: { habitId: habit.id, date: d, completed: true } })
+    }
+
+    const res = await request(app)
+      .get('/api/stats')
+      .set('Authorization', `Bearer ${token}`)
+
+    expect(res.status).toBe(200)
+    const { streaks } = res.body.data
+    expect(streaks.best.count).toBe(5)
+    expect(streaks.best.habitId).toBe(habit.id)
+    expect(streaks.current.length).toBeGreaterThan(0)
+    expect(streaks.current[0].count).toBe(5)
+  })
+
+  it('categoryBreakdown groups habits by category with correct percentages', async () => {
+    const { userId, token } = await createTestUser()
+
+    await prisma.habit.create({ data: { userId, name: 'Run', category: 'Health', position: 0 } })
+    await prisma.habit.create({ data: { userId, name: 'Yoga', category: 'Health', position: 1 } })
+    await prisma.habit.create({ data: { userId, name: 'Read', category: 'Learning', position: 2 } })
+    await prisma.habit.create({ data: { userId, name: 'Code', category: 'Learning', position: 3 } })
+
+    const res = await request(app)
+      .get('/api/stats')
+      .set('Authorization', `Bearer ${token}`)
+
+    expect(res.status).toBe(200)
+    const { categoryBreakdown } = res.body.data
+    expect(categoryBreakdown).toHaveLength(2)
+
+    const health = categoryBreakdown.find((c: { category: string }) => c.category === 'Health')
+    const learning = categoryBreakdown.find((c: { category: string }) => c.category === 'Learning')
+
+    expect(health).toBeDefined()
+    expect(health.count).toBe(2)
+    expect(health.percentage).toBeCloseTo(0.5)
+
+    expect(learning).toBeDefined()
+    expect(learning.count).toBe(2)
+    expect(learning.percentage).toBeCloseTo(0.5)
+  })
+
+  it('weeklyHeatmap contains an entry per active habit with 7 boolean days', async () => {
+    const { userId, token } = await createTestUser()
+    const h1 = await prisma.habit.create({ data: { userId, name: 'Run', position: 0 } })
+    await prisma.habit.create({ data: { userId, name: 'Read', position: 1 } })
+
+    // Log h1 for today
+    const today = new Date()
+    today.setUTCHours(0, 0, 0, 0)
+    await prisma.habitLog.create({ data: { habitId: h1.id, date: today, completed: true } })
+
+    const res = await request(app)
+      .get('/api/stats')
+      .set('Authorization', `Bearer ${token}`)
+
+    expect(res.status).toBe(200)
+    const { weeklyHeatmap } = res.body.data
+    expect(weeklyHeatmap).toHaveLength(2)
+
+    const runEntry = weeklyHeatmap.find((e: { habitId: string }) => e.habitId === h1.id)
+    expect(runEntry).toBeDefined()
+    expect(runEntry.days).toHaveLength(7)
+    // Today is last day (index 6)
+    expect(runEntry.days[6]).toBe(true)
+  })
+
+  it('activeHabits excludes archived habits', async () => {
+    const { userId, token } = await createTestUser()
+    await prisma.habit.create({ data: { userId, name: 'Active', position: 0, isArchived: false } })
+    await prisma.habit.create({ data: { userId, name: 'Archived', position: 1, isArchived: true } })
+
+    const res = await request(app)
+      .get('/api/stats')
+      .set('Authorization', `Bearer ${token}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.activeHabits).toBe(1)
+  })
+
+  it('thisMonth counts logs in current and previous month', async () => {
+    const { userId, token } = await createTestUser()
+    const habit = await prisma.habit.create({ data: { userId, name: 'Run', position: 0 } })
+
+    const now = new Date()
+    // Two logs this month
+    const thisMonth1 = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
+    const thisMonth2 = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 2))
+    // One log last month
+    const prevMonth1 = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 15))
+
+    await prisma.habitLog.create({ data: { habitId: habit.id, date: thisMonth1, completed: true } })
+    await prisma.habitLog.create({ data: { habitId: habit.id, date: thisMonth2, completed: true } })
+    await prisma.habitLog.create({ data: { habitId: habit.id, date: prevMonth1, completed: true } })
+
+    const res = await request(app)
+      .get('/api/stats')
+      .set('Authorization', `Bearer ${token}`)
+
+    expect(res.status).toBe(200)
+    expect(res.body.data.thisMonth.completions).toBe(2)
+    expect(res.body.data.thisMonth.previousMonth).toBe(1)
+  })
+})

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -5,6 +5,7 @@ import { authRoutes } from './routes/auth.js'
 import { authMiddleware } from './middleware/auth.js'
 import habitsRouter from './routes/habits.js'
 import trackingRouter from './routes/tracking.js'
+import statsRouter from './routes/stats.js'
 
 export function createApp() {
   const app = express()
@@ -21,6 +22,7 @@ export function createApp() {
   app.use('/api/auth', authRoutes)
   app.use('/api/habits', authMiddleware, habitsRouter)
   app.use('/api/tracking', authMiddleware, trackingRouter)
+  app.use('/api/stats', authMiddleware, statsRouter)
 
   // Global error handler
   app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {

--- a/server/src/routes/stats.ts
+++ b/server/src/routes/stats.ts
@@ -1,0 +1,235 @@
+import { Router, Request, Response, NextFunction } from 'express'
+import type { IRouter } from 'express'
+import { prisma } from '../lib/prisma.js'
+import type { AuthenticatedRequest } from '../middleware/auth.js'
+
+const router: IRouter = Router()
+
+function asyncHandler(
+  fn: (req: Request, res: Response, next: NextFunction) => Promise<void>
+) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    fn(req, res, next).catch(next)
+  }
+}
+
+function startOfDayUTC(date: Date): Date {
+  const d = new Date(date)
+  d.setUTCHours(0, 0, 0, 0)
+  return d
+}
+
+function dateOnlyKey(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+// GET / — return aggregate stats for the authenticated user
+router.get(
+  '/',
+  asyncHandler(async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    const userId = req.user!.userId
+
+    // Fetch all active habits
+    const habits = await prisma.habit.findMany({
+      where: { userId, isArchived: false },
+    })
+
+    const activeHabits = habits.length
+
+    // --- Today stats ---
+    const today = startOfDayUTC(new Date())
+    const todayLogs = await prisma.habitLog.findMany({
+      where: {
+        habitId: { in: habits.map((h) => h.id) },
+        date: today,
+        completed: true,
+      },
+    })
+    const todayCompleted = todayLogs.length
+    const todayTotal = activeHabits
+    const todayRate = todayTotal > 0 ? todayCompleted / todayTotal : 0
+
+    // --- This month vs previous month ---
+    const now = new Date()
+    const thisMonthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
+    const prevMonthStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1))
+    const prevMonthEnd = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 0, 23, 59, 59, 999)
+    )
+
+    const thisMonthLogs = await prisma.habitLog.count({
+      where: {
+        habitId: { in: habits.map((h) => h.id) },
+        date: { gte: thisMonthStart },
+        completed: true,
+      },
+    })
+    const prevMonthLogs = await prisma.habitLog.count({
+      where: {
+        habitId: { in: habits.map((h) => h.id) },
+        date: { gte: prevMonthStart, lte: prevMonthEnd },
+        completed: true,
+      },
+    })
+
+    // --- Streaks ---
+    interface StreakResult {
+      habitId: string
+      habitName: string
+      count: number
+    }
+
+    const streakResults: StreakResult[] = []
+
+    for (const habit of habits) {
+      const logs = await prisma.habitLog.findMany({
+        where: { habitId: habit.id, completed: true },
+        orderBy: { date: 'desc' },
+      })
+
+      if (logs.length === 0) {
+        streakResults.push({ habitId: habit.id, habitName: habit.name, count: 0 })
+        continue
+      }
+
+      // Build a set of completed date strings
+      const completedDates = new Set(logs.map((l) => dateOnlyKey(new Date(l.date))))
+
+      // Calculate current streak (consecutive days ending today or yesterday)
+      let currentStreak = 0
+      const checkDate = startOfDayUTC(new Date())
+
+      // Allow streak to include today or start from yesterday
+      if (!completedDates.has(dateOnlyKey(checkDate))) {
+        checkDate.setUTCDate(checkDate.getUTCDate() - 1)
+      }
+
+      while (completedDates.has(dateOnlyKey(checkDate))) {
+        currentStreak++
+        checkDate.setUTCDate(checkDate.getUTCDate() - 1)
+      }
+
+      streakResults.push({ habitId: habit.id, habitName: habit.name, count: currentStreak })
+    }
+
+    // Best streak: find the longest ever consecutive streak per habit
+    interface BestStreakResult {
+      habitId: string
+      habitName: string
+      count: number
+    }
+    const bestStreakResults: BestStreakResult[] = []
+
+    for (const habit of habits) {
+      const logs = await prisma.habitLog.findMany({
+        where: { habitId: habit.id, completed: true },
+        orderBy: { date: 'asc' },
+      })
+
+      if (logs.length === 0) {
+        bestStreakResults.push({ habitId: habit.id, habitName: habit.name, count: 0 })
+        continue
+      }
+
+      const dates = logs.map((l) => dateOnlyKey(new Date(l.date)))
+      let best = 1
+      let current = 1
+
+      for (let i = 1; i < dates.length; i++) {
+        const prev = new Date(dates[i - 1] + 'T00:00:00.000Z')
+        const curr = new Date(dates[i] + 'T00:00:00.000Z')
+        const diffDays = (curr.getTime() - prev.getTime()) / (1000 * 60 * 60 * 24)
+        if (diffDays === 1) {
+          current++
+          if (current > best) best = current
+        } else {
+          current = 1
+        }
+      }
+
+      bestStreakResults.push({ habitId: habit.id, habitName: habit.name, count: best })
+    }
+
+    // Sort current streaks descending
+    const sortedCurrentStreaks = streakResults
+      .filter((s) => s.count > 0)
+      .sort((a, b) => b.count - a.count)
+
+    const overallBest = bestStreakResults.sort((a, b) => b.count - a.count)[0] ?? {
+      habitId: '',
+      habitName: '',
+      count: 0,
+    }
+
+    // --- Category breakdown ---
+    const categoryCounts: Record<string, number> = {}
+    for (const habit of habits) {
+      const cat = habit.category ?? 'Uncategorized'
+      categoryCounts[cat] = (categoryCounts[cat] ?? 0) + 1
+    }
+
+    const categoryBreakdown = Object.entries(categoryCounts).map(([category, count]) => ({
+      category,
+      count,
+      percentage: activeHabits > 0 ? count / activeHabits : 0,
+    }))
+
+    // --- Weekly heatmap (last 7 days Mon–Sun of the current week) ---
+    // Build an array of the last 7 days (today and 6 days before)
+    const weekDays: Date[] = []
+    for (let i = 6; i >= 0; i--) {
+      const d = startOfDayUTC(new Date())
+      d.setUTCDate(d.getUTCDate() - i)
+      weekDays.push(d)
+    }
+
+    const weekStart = weekDays[0]
+    const weekEnd = weekDays[6]
+
+    const weekLogs = await prisma.habitLog.findMany({
+      where: {
+        habitId: { in: habits.map((h) => h.id) },
+        date: { gte: weekStart, lte: weekEnd },
+        completed: true,
+      },
+    })
+
+    const weeklyHeatmap = habits.map((habit) => {
+      const habitLogs = weekLogs.filter((l) => l.habitId === habit.id)
+      const completedSet = new Set(habitLogs.map((l) => dateOnlyKey(new Date(l.date))))
+      const days = weekDays.map((d) => completedSet.has(dateOnlyKey(d)))
+      return {
+        habitId: habit.id,
+        habitName: habit.name,
+        days,
+      }
+    })
+
+    res.status(200).json({
+      data: {
+        today: {
+          completed: todayCompleted,
+          total: todayTotal,
+          rate: todayRate,
+        },
+        streaks: {
+          best: {
+            habitId: overallBest.habitId,
+            habitName: overallBest.habitName,
+            count: overallBest.count,
+          },
+          current: sortedCurrentStreaks,
+        },
+        thisMonth: {
+          completions: thisMonthLogs,
+          previousMonth: prevMonthLogs,
+        },
+        activeHabits,
+        categoryBreakdown,
+        weeklyHeatmap,
+      },
+    })
+  })
+)
+
+export default router


### PR DESCRIPTION
## Summary

- Adds `GET /api/stats` endpoint returning today completion rate, streaks (current + best), monthly completions vs previous month, active habit count, category breakdown, and 7-day weekly heatmap
- Adds Pinia `useStatsStore` with `fetchStats()` action and Bearer token auth
- Adds TypeScript interfaces in `client/src/types/stats.ts` for all stats data shapes
- Adds five reusable Vue 3 dashboard components: `CompletionCircle` (animated SVG progress ring), `StreakCard` (KPI with flame icon), `WeeklyHeatmap` (7-day grid), `CategoryDonut` (SVG donut chart with legend), `KpiCard` (generic metric widget)
- Full test coverage: 8 server integration tests + 7 client store unit tests (78 tests total pass)

## Test plan

- [x] `pnpm test` passes all 78 tests (50 server + 28 client)
- [x] GET /api/stats returns 401 without token
- [x] Stats reflect actual habit + log data (streaks, today rate, monthly counts, categories)
- [x] Weekly heatmap returns 7 boolean days per active habit
- [x] Archived habits excluded from activeHabits count
- [x] Stats store sets loading true/false correctly, throws on API error

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)