### PR TITLE
feat(responsive): add mobile bottom nav and breakpoint composable

### DIFF
--- a/client/src/__tests__/use-breakpoint.test.ts
+++ b/client/src/__tests__/use-breakpoint.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+import { useBreakpoint } from '../composables/useBreakpoint'
+
+// Helper: create a minimal component that uses the composable so we can test
+// lifecycle hooks (onMounted / onUnmounted) properly.
+function makeWrapper() {
+  return defineComponent({
+    setup() {
+      return useBreakpoint()
+    },
+    template: '<div />',
+  })
+}
+
+// Build a minimal matchMedia mock that can be toggled per query.
+function buildMatchMediaMock(initialMatches: Record<string, boolean>) {
+  const listeners: Record<string, Array<(e: MediaQueryListEvent) => void>> = {}
+
+  const mock = vi.fn().mockImplementation((query: string) => {
+    const mql = {
+      matches: initialMatches[query] ?? false,
+      media: query,
+      addEventListener: vi.fn((event: string, cb: (e: MediaQueryListEvent) => void) => {
+        if (!listeners[query]) listeners[query] = []
+        listeners[query].push(cb)
+      }),
+      removeEventListener: vi.fn((event: string, cb: (e: MediaQueryListEvent) => void) => {
+        if (listeners[query]) {
+          listeners[query] = listeners[query].filter((l) => l !== cb)
+        }
+      }),
+    }
+    return mql
+  })
+
+  function trigger(query: string, matches: boolean) {
+    if (listeners[query]) {
+      listeners[query].forEach((cb) =>
+        cb({ matches, media: query } as MediaQueryListEvent),
+      )
+    }
+  }
+
+  return { mock, trigger }
+}
+
+describe('useBreakpoint', () => {
+  const MOBILE_QUERY = '(max-width: 767px)'
+  const TABLET_QUERY = '(min-width: 768px) and (max-width: 1023px)'
+  const DESKTOP_QUERY = '(min-width: 1024px)'
+
+  let originalMatchMedia: typeof window.matchMedia
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: originalMatchMedia,
+    })
+    vi.clearAllMocks()
+  })
+
+  it('returns isMobile=true when viewport is < 768px', async () => {
+    const { mock } = buildMatchMediaMock({
+      [MOBILE_QUERY]: true,
+      [TABLET_QUERY]: false,
+      [DESKTOP_QUERY]: false,
+    })
+    Object.defineProperty(window, 'matchMedia', { writable: true, value: mock })
+
+    const wrapper = mount(makeWrapper())
+    await flushPromises()
+
+    expect(wrapper.vm.isMobile).toBe(true)
+    expect(wrapper.vm.isTablet).toBe(false)
+    expect(wrapper.vm.isDesktop).toBe(false)
+  })
+
+  it('returns isTablet=true when viewport is 768-1023px', async () => {
+    const { mock } = buildMatchMediaMock({
+      [MOBILE_QUERY]: false,
+      [TABLET_QUERY]: true,
+      [DESKTOP_QUERY]: false,
+    })
+    Object.defineProperty(window, 'matchMedia', { writable: true, value: mock })
+
+    const wrapper = mount(makeWrapper())
+    await flushPromises()
+
+    expect(wrapper.vm.isMobile).toBe(false)
+    expect(wrapper.vm.isTablet).toBe(true)
+    expect(wrapper.vm.isDesktop).toBe(false)
+  })
+
+  it('returns isDesktop=true when viewport is >= 1024px', async () => {
+    const { mock } = buildMatchMediaMock({
+      [MOBILE_QUERY]: false,
+      [TABLET_QUERY]: false,
+      [DESKTOP_QUERY]: true,
+    })
+    Object.defineProperty(window, 'matchMedia', { writable: true, value: mock })
+
+    const wrapper = mount(makeWrapper())
+    await flushPromises()
+
+    expect(wrapper.vm.isMobile).toBe(false)
+    expect(wrapper.vm.isTablet).toBe(false)
+    expect(wrapper.vm.isDesktop).toBe(true)
+  })
+
+  it('all flags are false when no media query matches (SSR-like state)', async () => {
+    const { mock } = buildMatchMediaMock({
+      [MOBILE_QUERY]: false,
+      [TABLET_QUERY]: false,
+      [DESKTOP_QUERY]: false,
+    })
+    Object.defineProperty(window, 'matchMedia', { writable: true, value: mock })
+
+    const wrapper = mount(makeWrapper())
+    await flushPromises()
+
+    expect(wrapper.vm.isMobile).toBe(false)
+    expect(wrapper.vm.isTablet).toBe(false)
+    expect(wrapper.vm.isDesktop).toBe(false)
+  })
+
+  it('reacts to a change event — switches to mobile', async () => {
+    const { mock, trigger } = buildMatchMediaMock({
+      [MOBILE_QUERY]: false,
+      [TABLET_QUERY]: false,
+      [DESKTOP_QUERY]: true,
+    })
+    Object.defineProperty(window, 'matchMedia', { writable: true, value: mock })
+
+    const wrapper = mount(makeWrapper())
+    await flushPromises()
+
+    expect(wrapper.vm.isDesktop).toBe(true)
+
+    // Simulate resize to mobile
+    trigger(MOBILE_QUERY, true)
+    await flushPromises()
+
+    expect(wrapper.vm.isMobile).toBe(true)
+  })
+
+  it('reacts to a change event — switches to desktop', async () => {
+    const { mock, trigger } = buildMatchMediaMock({
+      [MOBILE_QUERY]: true,
+      [TABLET_QUERY]: false,
+      [DESKTOP_QUERY]: false,
+    })
+    Object.defineProperty(window, 'matchMedia', { writable: true, value: mock })
+
+    const wrapper = mount(makeWrapper())
+    await flushPromises()
+
+    expect(wrapper.vm.isMobile).toBe(true)
+
+    trigger(DESKTOP_QUERY, true)
+    await flushPromises()
+
+    expect(wrapper.vm.isDesktop).toBe(true)
+  })
+
+  it('removes event listeners on unmount', async () => {
+    const { mock } = buildMatchMediaMock({
+      [MOBILE_QUERY]: false,
+      [TABLET_QUERY]: false,
+      [DESKTOP_QUERY]: true,
+    })
+    Object.defineProperty(window, 'matchMedia', { writable: true, value: mock })
+
+    const wrapper = mount(makeWrapper())
+    await flushPromises()
+
+    // Each mql instance tracks removeEventListener calls
+    const mqlInstances = (mock as ReturnType<typeof vi.fn>).mock.results.map(
+      (r: { value: { removeEventListener: ReturnType<typeof vi.fn> } }) => r.value,
+    )
+
+    wrapper.unmount()
+
+    // Every mql instance should have had removeEventListener called once
+    mqlInstances.forEach((mql: { removeEventListener: ReturnType<typeof vi.fn> }) => {
+      expect(mql.removeEventListener).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/client/src/assets/main.css
+++ b/client/src/assets/main.css
@@ -1,6 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&family=Inter:wght@300;400;500;600;700&display=swap');
 
 @import "tailwindcss";
+@import "./responsive.css";
 
 :root {
   --bg: #FFF8F0;

--- a/client/src/assets/responsive.css
+++ b/client/src/assets/responsive.css
@@ -1,0 +1,121 @@
+/* =========================================
+   Responsive Utilities — HabitTracker v2
+   ========================================= */
+
+/* ------------------------------------------
+   Touch targets: minimum 44x44px on mobile
+   ------------------------------------------ */
+@media (max-width: 767px) {
+  button,
+  a,
+  [role='button'],
+  input[type='checkbox'],
+  input[type='radio'],
+  select {
+    min-height: 44px;
+    min-width: 44px;
+  }
+
+  /* Inline links don't need forced min-width */
+  p a,
+  li a {
+    min-width: unset;
+    min-height: unset;
+    display: inline;
+  }
+}
+
+/* ------------------------------------------
+   Prevent text overflow on small screens
+   ------------------------------------------ */
+h1, h2, h3, h4, h5, h6 {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+p, li, td, th {
+  overflow-wrap: break-word;
+}
+
+/* ------------------------------------------
+   Max-width content constraint (wide screens)
+   ------------------------------------------ */
+.content-container {
+  width: 100%;
+  max-width: 1320px;
+  margin-inline: auto;
+  padding-inline: 16px;
+}
+
+@media (min-width: 768px) {
+  .content-container {
+    padding-inline: 24px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .content-container {
+    padding-inline: 32px;
+  }
+}
+
+/* ------------------------------------------
+   Card stacking on mobile
+   ------------------------------------------ */
+@media (max-width: 767px) {
+  .card-grid {
+    display: flex !important;
+    flex-direction: column;
+    gap: 12px;
+  }
+}
+
+/* ------------------------------------------
+   Forms: full-width on mobile
+   ------------------------------------------ */
+@media (max-width: 767px) {
+  .form-field,
+  .form-group {
+    width: 100%;
+  }
+
+  input[type='text'],
+  input[type='email'],
+  input[type='password'],
+  input[type='number'],
+  input[type='search'],
+  input[type='tel'],
+  input[type='url'],
+  select,
+  textarea {
+    width: 100%;
+    box-sizing: border-box;
+  }
+}
+
+/* ------------------------------------------
+   Modals: full-screen on mobile (< 480px)
+   ------------------------------------------ */
+@media (max-width: 479px) {
+  .modal,
+  [role='dialog'] {
+    position: fixed !important;
+    inset: 0 !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    height: 100% !important;
+    max-height: 100% !important;
+    border-radius: 0 !important;
+    margin: 0 !important;
+    overflow-y: auto;
+  }
+}
+
+/* ------------------------------------------
+   Mobile body padding for bottom nav
+   ------------------------------------------ */
+@media (max-width: 767px) {
+  body {
+    padding-bottom: 64px;
+  }
+}

--- a/client/src/components/layout/MobileBottomNav.vue
+++ b/client/src/components/layout/MobileBottomNav.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+import { Home, BookOpen, CheckSquare, Settings } from 'lucide-vue-next'
+
+const route = useRoute()
+
+interface NavItem {
+  label: string
+  to: string
+  icon: typeof Home
+}
+
+const navItems: NavItem[] = [
+  { label: 'Home', to: '/dashboard', icon: Home },
+  { label: 'Habits', to: '/habits', icon: BookOpen },
+  { label: 'Today', to: '/today', icon: CheckSquare },
+  { label: 'Settings', to: '/settings', icon: Settings },
+]
+
+function isActive(to: string): boolean {
+  return route.path === to || route.path.startsWith(to + '/')
+}
+
+const activeColor = computed(() => 'var(--primary)')
+</script>
+
+<template>
+  <nav class="mobile-bottom-nav" aria-label="Mobile navigation">
+    <RouterLink
+      v-for="item in navItems"
+      :key="item.to"
+      :to="item.to"
+      class="nav-item"
+      :class="{ 'nav-item--active': isActive(item.to) }"
+      :aria-current="isActive(item.to) ? 'page' : undefined"
+    >
+      <component :is="item.icon" :size="22" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" class="nav-icon" />
+      <span class="nav-label">{{ item.label }}</span>
+    </RouterLink>
+  </nav>
+</template>
+
+<style scoped>
+.mobile-bottom-nav {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  .mobile-bottom-nav {
+    display: flex;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 64px;
+    background: var(--surface);
+    border-top: 1px solid var(--border);
+    z-index: 100;
+    align-items: stretch;
+  }
+}
+
+.nav-item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  min-height: 44px;
+  min-width: 44px;
+  text-decoration: none;
+  color: var(--text-muted);
+  transition: color 0.15s ease;
+  cursor: pointer;
+}
+
+.nav-item--active,
+.nav-item--active .nav-icon {
+  color: v-bind(activeColor);
+}
+
+.nav-icon {
+  flex-shrink: 0;
+  color: inherit;
+}
+
+.nav-label {
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 1;
+  color: inherit;
+  font-family: 'Inter', sans-serif;
+}
+</style>

--- a/client/src/composables/useBreakpoint.ts
+++ b/client/src/composables/useBreakpoint.ts
@@ -1,0 +1,44 @@
+import { ref, onMounted, onUnmounted } from 'vue'
+
+export function useBreakpoint() {
+  const isMobile = ref(false)   // < 768px
+  const isTablet = ref(false)   // 768-1023px
+  const isDesktop = ref(false)  // >= 1024px
+
+  const mobileQuery = window.matchMedia('(max-width: 767px)')
+  const tabletQuery = window.matchMedia('(min-width: 768px) and (max-width: 1023px)')
+  const desktopQuery = window.matchMedia('(min-width: 1024px)')
+
+  function update() {
+    isMobile.value = mobileQuery.matches
+    isTablet.value = tabletQuery.matches
+    isDesktop.value = desktopQuery.matches
+  }
+
+  function onMobileChange(e: MediaQueryListEvent) {
+    isMobile.value = e.matches
+  }
+
+  function onTabletChange(e: MediaQueryListEvent) {
+    isTablet.value = e.matches
+  }
+
+  function onDesktopChange(e: MediaQueryListEvent) {
+    isDesktop.value = e.matches
+  }
+
+  onMounted(() => {
+    update()
+    mobileQuery.addEventListener('change', onMobileChange)
+    tabletQuery.addEventListener('change', onTabletChange)
+    desktopQuery.addEventListener('change', onDesktopChange)
+  })
+
+  onUnmounted(() => {
+    mobileQuery.removeEventListener('change', onMobileChange)
+    tabletQuery.removeEventListener('change', onTabletChange)
+    desktopQuery.removeEventListener('change', onDesktopChange)
+  })
+
+  return { isMobile, isTablet, isDesktop }
+}


### PR DESCRIPTION
Closes #16

## Summary
- Add `MobileBottomNav.vue`: fixed 64px bottom bar with 4 nav items (Home, Habits, Today, Settings), visible only on mobile (< 768px), active state uses `var(--primary)`, Lucide icons at 22px with 1.8 stroke
- Add `useBreakpoint.ts` composable: reactive `isMobile` / `isTablet` / `isDesktop` refs via `matchMedia`, event listeners cleaned up on `onUnmounted`
- Add `responsive.css`: touch-target rules (≥44px), text overflow protection, `content-container` max-width 1320px, card stacking, full-width forms, full-screen modals on <480px, bottom body padding for nav bar
- Import `responsive.css` in `main.css`

## Test plan
- [x] `pnpm test:client` — 7 test files, 46 tests all pass
- [ ] Visually verify bottom nav appears on < 768px and is hidden on desktop
- [ ] Confirm active nav item highlights in `var(--primary)` when route matches
- [ ] Resize to < 480px and confirm modal full-screen rule applies
- [ ] Confirm touch targets are ≥ 44px on a real mobile device

🤖 Generated with [Claude Code](https://claude.com/claude-code)