### PR TITLE
feat(dashboard): add bento grid layout with app shell

### DIFF
--- a/client/src/__tests__/bento-grid.test.ts
+++ b/client/src/__tests__/bento-grid.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import BentoCard from '@/components/dashboard/BentoCard.vue'
+
+describe('BentoCard', () => {
+  it('renders with size class "small" by default', () => {
+    const wrapper = mount(BentoCard)
+    expect(wrapper.classes()).toContain('bento-card--small')
+  })
+
+  it('renders with size class "medium" when size prop is medium', () => {
+    const wrapper = mount(BentoCard, {
+      props: { size: 'medium' },
+    })
+    expect(wrapper.classes()).toContain('bento-card--medium')
+  })
+
+  it('renders with size class "large" when size prop is large', () => {
+    const wrapper = mount(BentoCard, {
+      props: { size: 'large' },
+    })
+    expect(wrapper.classes()).toContain('bento-card--large')
+  })
+
+  it('renders title when provided', () => {
+    const wrapper = mount(BentoCard, {
+      props: { title: 'Test Title' },
+    })
+    expect(wrapper.text()).toContain('Test Title')
+  })
+
+  it('renders icon when provided', () => {
+    const wrapper = mount(BentoCard, {
+      props: { icon: '🔥' },
+    })
+    expect(wrapper.text()).toContain('🔥')
+  })
+
+  it('does not render header when neither title nor icon provided', () => {
+    const wrapper = mount(BentoCard)
+    expect(wrapper.find('.bento-card__header').exists()).toBe(false)
+  })
+
+  it('renders default slot content', () => {
+    const wrapper = mount(BentoCard, {
+      slots: {
+        default: '<span class="slot-content">Hello</span>',
+      },
+    })
+    expect(wrapper.find('.slot-content').exists()).toBe(true)
+    expect(wrapper.find('.slot-content').text()).toBe('Hello')
+  })
+
+  it('always has bento-card base class', () => {
+    const sizes = ['small', 'medium', 'large'] as const
+    for (const size of sizes) {
+      const wrapper = mount(BentoCard, { props: { size } })
+      expect(wrapper.classes()).toContain('bento-card')
+    }
+  })
+})

--- a/client/src/components/dashboard/BentoCard.vue
+++ b/client/src/components/dashboard/BentoCard.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+interface Props {
+  size?: 'small' | 'medium' | 'large'
+  title?: string
+  icon?: string
+}
+
+withDefaults(defineProps<Props>(), {
+  size: 'small',
+})
+</script>
+
+<template>
+  <div
+    class="bento-card"
+    :class="[`bento-card--${size}`]"
+  >
+    <div v-if="title || icon" class="bento-card__header">
+      <span v-if="icon" class="bento-card__icon" aria-hidden="true">{{ icon }}</span>
+      <span v-if="title" class="bento-card__title">{{ title }}</span>
+    </div>
+    <div class="bento-card__content">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.bento-card {
+  background: var(--surface);
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  box-shadow: 0 2px 12px rgba(45, 43, 61, 0.04);
+  padding: 32px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 200px;
+}
+
+.bento-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 20px rgba(255, 107, 157, 0.08);
+}
+
+/* Size — small: 1 col span */
+.bento-card--small {
+  grid-column: span 1;
+  grid-row: span 1;
+}
+
+/* Size — medium: 2 col span */
+.bento-card--medium {
+  grid-column: span 1;
+  grid-row: span 1;
+}
+
+/* Size — large: 2 col + 2 row span */
+.bento-card--large {
+  grid-column: span 1;
+  grid-row: span 1;
+}
+
+@media (min-width: 768px) {
+  .bento-card--medium {
+    grid-column: span 2;
+  }
+
+  .bento-card--large {
+    grid-column: span 2;
+    grid-row: span 2;
+  }
+}
+
+@media (min-width: 1024px) {
+  .bento-card--medium {
+    grid-column: span 2;
+  }
+
+  .bento-card--large {
+    grid-column: span 2;
+    grid-row: span 2;
+  }
+}
+
+.bento-card__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.bento-card__icon {
+  font-size: 16px;
+  line-height: 1;
+}
+
+.bento-card__title {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.bento-card__content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+</style>

--- a/client/src/components/dashboard/BentoGrid.vue
+++ b/client/src/components/dashboard/BentoGrid.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+// BentoGrid — slot-based CSS grid container
+// Desktop (>=1024px): 4 cols, gap 24px
+// Tablet (>=768px):   2 cols, gap 20px
+// Mobile (<768px):    1 col,  gap 16px
+</script>
+
+<template>
+  <div class="bento-grid">
+    <slot />
+  </div>
+</template>
+
+<style scoped>
+.bento-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+  grid-auto-rows: minmax(200px, auto);
+}
+
+@media (min-width: 768px) {
+  .bento-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 20px;
+  }
+}
+
+@media (min-width: 1024px) {
+  .bento-grid {
+    grid-template-columns: repeat(4, 1fr);
+    gap: 24px;
+  }
+}
+</style>

--- a/client/src/components/layout/AppShell.vue
+++ b/client/src/components/layout/AppShell.vue
@@ -1,0 +1,315 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+
+const route = useRoute()
+const router = useRouter()
+const authStore = useAuthStore()
+
+const greeting = computed(() => {
+  const hour = new Date().getHours()
+  if (hour < 12) return 'Good morning'
+  if (hour < 17) return 'Good afternoon'
+  return 'Good evening'
+})
+
+const formattedDate = computed(() =>
+  new Date().toLocaleDateString('en-US', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }),
+)
+
+const userName = computed(() => authStore.user?.name ?? '')
+
+const navItems = [
+  { name: 'Dashboard', to: '/dashboard', icon: 'home' },
+  { name: 'Habits', to: '/habits', icon: 'check-circle' },
+  { name: 'Today', to: '/today', icon: 'bar-chart' },
+  { name: 'Settings', to: '/settings', icon: 'settings' },
+]
+
+function isActive(path: string): boolean {
+  return route.path === path
+}
+
+function handleNewHabit() {
+  router.push('/habits')
+}
+</script>
+
+<template>
+  <div class="app-shell">
+    <!-- Sidebar -->
+    <aside class="sidebar">
+      <div class="sidebar__logo">
+        <span class="sidebar__logo-h">H</span>abitTracker
+      </div>
+
+      <nav class="sidebar__nav" aria-label="Main navigation">
+        <RouterLink
+          v-for="item in navItems"
+          :key="item.to"
+          :to="item.to"
+          class="sidebar__nav-item"
+          :class="{ 'sidebar__nav-item--active': isActive(item.to) }"
+        >
+          <!-- Home icon -->
+          <svg
+            v-if="item.icon === 'home'"
+            class="sidebar__nav-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+            <polyline points="9 22 9 12 15 12 15 22" />
+          </svg>
+
+          <!-- Check-circle icon -->
+          <svg
+            v-else-if="item.icon === 'check-circle'"
+            class="sidebar__nav-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+            <polyline points="22 4 12 14.01 9 11.01" />
+          </svg>
+
+          <!-- Bar-chart icon (Today) -->
+          <svg
+            v-else-if="item.icon === 'bar-chart'"
+            class="sidebar__nav-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <line x1="18" y1="20" x2="18" y2="10" />
+            <line x1="12" y1="20" x2="12" y2="4" />
+            <line x1="6" y1="20" x2="6" y2="14" />
+          </svg>
+
+          <!-- Settings icon -->
+          <svg
+            v-else-if="item.icon === 'settings'"
+            class="sidebar__nav-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="12" cy="12" r="3" />
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+          </svg>
+
+          <span class="sidebar__nav-label">{{ item.name }}</span>
+        </RouterLink>
+      </nav>
+    </aside>
+
+    <!-- Main content -->
+    <main class="main">
+      <!-- Page header -->
+      <header class="main__header">
+        <div class="main__header-text">
+          <h1 class="main__greeting">{{ greeting }}<span v-if="userName">, {{ userName }}</span></h1>
+          <p class="main__date">{{ formattedDate }}</p>
+        </div>
+        <button class="main__new-habit-btn" @click="handleNewHabit">
+          <span aria-hidden="true">+</span> New Habit
+        </button>
+      </header>
+
+      <!-- Slot for page content -->
+      <div class="main__content">
+        <slot />
+      </div>
+    </main>
+  </div>
+</template>
+
+<style scoped>
+.app-shell {
+  display: flex;
+  min-height: 100vh;
+  background: var(--bg);
+}
+
+/* ── Sidebar ─────────────────────────────────────────── */
+.sidebar {
+  display: none;
+  width: 240px;
+  min-width: 240px;
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  flex-direction: column;
+  gap: 32px;
+  padding: 32px 16px;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow-y: auto;
+}
+
+@media (min-width: 768px) {
+  .sidebar {
+    display: flex;
+  }
+}
+
+.sidebar__logo {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--text);
+  padding: 0 8px;
+  letter-spacing: -0.01em;
+}
+
+.sidebar__logo-h {
+  color: var(--primary);
+}
+
+.sidebar__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sidebar__nav-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition: background 0.12s, color 0.12s;
+}
+
+.sidebar__nav-item:hover {
+  background: var(--surface-alt);
+  color: var(--text);
+}
+
+.sidebar__nav-item--active {
+  background: var(--surface-alt);
+  color: var(--primary);
+}
+
+.sidebar__nav-icon {
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+
+.sidebar__nav-item--active .sidebar__nav-icon,
+.sidebar__nav-item:hover .sidebar__nav-icon {
+  opacity: 1;
+}
+
+.sidebar__nav-label {
+  flex: 1;
+}
+
+/* ── Main content ────────────────────────────────────── */
+.main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 48px 32px;
+  gap: 32px;
+}
+
+@media (max-width: 767px) {
+  .main {
+    padding: 24px 16px;
+  }
+}
+
+.main__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.main__greeting {
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.2;
+}
+
+.main__date {
+  font-size: 14px;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+
+.main__new-habit-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 20px;
+  border-radius: 12px;
+  border: none;
+  background: var(--primary);
+  color: white;
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.12s, transform 0.1s;
+  white-space: nowrap;
+}
+
+.main__new-habit-btn:hover {
+  background: var(--primary-dark);
+}
+
+.main__new-habit-btn:active {
+  transform: scale(0.97);
+}
+
+.main__content {
+  flex: 1;
+}
+</style>

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -30,6 +30,7 @@ const router = createRouter({
       path: '/habits',
       name: 'habits',
       component: () => import('../views/HabitsView.vue'),
+      meta: { requiresAuth: true },
     },
     {
       path: '/today',

--- a/client/src/views/DashboardView.vue
+++ b/client/src/views/DashboardView.vue
@@ -1,87 +1,189 @@
 <script setup lang="ts">
-import { useAuthStore } from '@/stores/auth'
-import { useRouter } from 'vue-router'
+import { computed, onMounted, ref } from 'vue'
+import AppShell from '@/components/layout/AppShell.vue'
+import BentoGrid from '@/components/dashboard/BentoGrid.vue'
+import BentoCard from '@/components/dashboard/BentoCard.vue'
+import TodayChecklist from '@/components/tracking/TodayChecklist.vue'
+import CompletionCircle from '@/components/dashboard/CompletionCircle.vue'
+import StreakCard from '@/components/dashboard/StreakCard.vue'
+import WeeklyHeatmap from '@/components/dashboard/WeeklyHeatmap.vue'
+import CategoryDonut from '@/components/dashboard/CategoryDonut.vue'
+import KpiCard from '@/components/dashboard/KpiCard.vue'
+import { useStatsStore } from '@/stores/stats'
+import { useHabitsStore } from '@/stores/habits'
+import { useTrackingStore } from '@/stores/tracking'
 
-const authStore = useAuthStore()
-const router = useRouter()
+const statsStore = useStatsStore()
+const habitsStore = useHabitsStore()
+const trackingStore = useTrackingStore()
 
-function handleLogout() {
-  authStore.logout()
-  router.push('/login')
-}
+const isLoading = ref(true)
+const mounted = ref(false)
+
+const todayRate = computed(() => statsStore.stats?.today.rate ?? 0)
+
+const bestStreak = computed(() => statsStore.stats?.streaks.best)
+
+const weeklyHeatmap = computed(() => statsStore.stats?.weeklyHeatmap ?? [])
+
+const categoryData = computed(() => statsStore.stats?.categoryBreakdown ?? [])
+
+const activeHabitsCount = computed(() => statsStore.stats?.activeHabits ?? 0)
+
+const thisMonthCompletions = computed(() => statsStore.stats?.thisMonth.completions ?? 0)
+
+const thisMonthTrend = computed(() => {
+  const s = statsStore.stats
+  if (!s) return undefined
+  const diff = s.thisMonth.completions - s.thisMonth.previousMonth
+  if (diff === 0) return undefined
+  return diff > 0 ? `+${diff} vs last month` : `${diff} vs last month`
+})
+
+onMounted(async () => {
+  try {
+    await Promise.all([
+      statsStore.fetchStats(),
+      habitsStore.fetchHabits(),
+      trackingStore.fetchTodayLogs(),
+    ])
+  } catch {
+    // silently handle — child components show empty states
+  } finally {
+    isLoading.value = false
+    // trigger stagger animation
+    requestAnimationFrame(() => {
+      mounted.value = true
+    })
+  }
+})
 </script>
 
 <template>
-  <div class="dashboard-page">
-    <div class="dashboard-card">
-      <h1 class="dashboard-title">Dashboard</h1>
-      <p class="dashboard-subtitle">
-        Welcome back{{ authStore.user?.name ? `, ${authStore.user.name}` : '' }}!
-      </p>
-      <p class="dashboard-note">Your habit dashboard is coming soon.</p>
-      <button class="logout-btn" @click="handleLogout">Sign out</button>
-    </div>
-  </div>
+  <AppShell>
+    <BentoGrid>
+      <!-- Today's Habits — large (2 col + 2 row) -->
+      <BentoCard size="large" title="Today's Habits" icon="✅">
+        <div v-if="isLoading" class="skeleton skeleton--list" />
+        <TodayChecklist v-else />
+      </BentoCard>
+
+      <!-- Today completion — small -->
+      <BentoCard size="small" title="Today" icon="🎯">
+        <div v-if="isLoading" class="skeleton skeleton--circle" />
+        <div v-else class="card-center">
+          <CompletionCircle :percentage="todayRate" />
+        </div>
+      </BentoCard>
+
+      <!-- Best Streak — small -->
+      <BentoCard size="small" title="Best Streak" icon="🔥">
+        <div v-if="isLoading" class="skeleton skeleton--text" />
+        <StreakCard
+          v-else-if="bestStreak"
+          :count="bestStreak.count"
+          :habit-name="bestStreak.habitName"
+        />
+        <div v-else class="empty-state">No streak data yet</div>
+      </BentoCard>
+
+      <!-- Weekly Overview — medium (2 col) -->
+      <BentoCard size="medium" title="Weekly Overview" icon="📅">
+        <div v-if="isLoading" class="skeleton skeleton--heatmap" />
+        <WeeklyHeatmap v-else-if="weeklyHeatmap.length > 0" :data="weeklyHeatmap" />
+        <div v-else class="empty-state">No weekly data yet</div>
+      </BentoCard>
+
+      <!-- Categories — medium (2 col) -->
+      <BentoCard size="medium" title="Categories" icon="🍩">
+        <div v-if="isLoading" class="skeleton skeleton--donut" />
+        <CategoryDonut v-else-if="categoryData.length > 0" :data="categoryData" />
+        <div v-else class="empty-state">No category data yet</div>
+      </BentoCard>
+
+      <!-- Active Habits — small -->
+      <BentoCard size="small" title="Active Habits" icon="⚡">
+        <div v-if="isLoading" class="skeleton skeleton--kpi" />
+        <KpiCard v-else :value="activeHabitsCount" label="Active habits" />
+      </BentoCard>
+
+      <!-- This Month — small -->
+      <BentoCard size="small" title="This Month" icon="📆">
+        <div v-if="isLoading" class="skeleton skeleton--kpi" />
+        <KpiCard
+          v-else
+          :value="thisMonthCompletions"
+          label="Completions"
+          :trend="thisMonthTrend"
+        />
+      </BentoCard>
+    </BentoGrid>
+  </AppShell>
 </template>
 
 <style scoped>
-.dashboard-page {
-  min-height: 100vh;
-  background: var(--bg);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 24px;
+/* Skeleton loaders */
+.skeleton {
+  border-radius: 12px;
+  background: linear-gradient(
+    90deg,
+    var(--border) 25%,
+    var(--surface-alt) 50%,
+    var(--border) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
 }
 
-.dashboard-card {
-  background: var(--surface);
-  border-radius: 20px;
-  border: 1px solid var(--border);
-  box-shadow: 0 4px 24px rgba(45, 43, 61, 0.06);
-  padding: 40px 36px;
-  text-align: center;
-  max-width: 440px;
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.skeleton--list {
+  height: 240px;
   width: 100%;
 }
 
-.dashboard-title {
-  font-family: 'Plus Jakarta Sans', sans-serif;
-  font-size: 28px;
-  font-weight: 700;
-  color: var(--text);
-  margin-bottom: 8px;
+.skeleton--circle {
+  width: 140px;
+  height: 140px;
+  border-radius: 50%;
+  margin: auto;
 }
 
-.dashboard-subtitle {
-  font-family: 'Inter', sans-serif;
-  font-size: 16px;
-  color: var(--text-secondary);
-  margin-bottom: 8px;
+.skeleton--text {
+  height: 80px;
+  width: 80%;
+  margin: auto;
 }
 
-.dashboard-note {
-  font-family: 'Inter', sans-serif;
+.skeleton--heatmap {
+  height: 120px;
+  width: 100%;
+}
+
+.skeleton--donut {
+  height: 120px;
+  width: 100%;
+}
+
+.skeleton--kpi {
+  height: 60px;
+  width: 60%;
+}
+
+.card-center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+}
+
+.empty-state {
   font-size: 13px;
   color: var(--text-muted);
-  margin-bottom: 24px;
-}
-
-.logout-btn {
-  padding: 10px 20px;
-  border-radius: 12px;
-  border: 1.5px solid var(--border);
-  background: transparent;
-  color: var(--text-secondary);
-  font-family: 'Inter', sans-serif;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background-color 0.15s ease;
-}
-
-.logout-btn:hover {
-  background: var(--surface-alt);
-  color: var(--text);
+  text-align: center;
+  padding: 24px 0;
 }
 </style>

--- a/client/src/views/HabitsView.vue
+++ b/client/src/views/HabitsView.vue
@@ -4,6 +4,7 @@ import { useHabitsStore } from '@/stores/habits'
 import HabitCard from '@/components/habits/HabitCard.vue'
 import HabitForm from '@/components/habits/HabitForm.vue'
 import HabitDeleteConfirm from '@/components/habits/HabitDeleteConfirm.vue'
+import AppShell from '@/components/layout/AppShell.vue'
 import type { Habit, CreateHabitData } from '@/types/habit'
 
 const store = useHabitsStore()
@@ -107,6 +108,7 @@ async function handleArchive(habit: Habit) {
 </script>
 
 <template>
+  <AppShell>
   <div class="habits-page">
     <!-- Header -->
     <div class="page-header">
@@ -187,6 +189,7 @@ async function handleArchive(habit: Habit) {
       @cancel="cancelDelete"
     />
   </div>
+  </AppShell>
 </template>
 
 <style scoped>

--- a/client/src/views/TodayView.vue
+++ b/client/src/views/TodayView.vue
@@ -1,60 +1,22 @@
 <script setup lang="ts">
+import AppShell from '@/components/layout/AppShell.vue'
 import TodayChecklist from '@/components/tracking/TodayChecklist.vue'
-
-const today = new Date().toLocaleDateString('en-US', {
-  weekday: 'long',
-  year: 'numeric',
-  month: 'long',
-  day: 'numeric',
-})
 </script>
 
 <template>
-  <div class="today-page">
+  <AppShell>
     <div class="today-container">
-      <!-- Page header -->
-      <div class="today-header">
-        <h1 class="today-header__title">Today</h1>
-        <p class="today-header__date">{{ today }}</p>
-      </div>
-
-      <!-- Checklist -->
       <TodayChecklist />
     </div>
-  </div>
+  </AppShell>
 </template>
 
 <style scoped>
-.today-page {
-  min-height: 100vh;
-  background: var(--bg);
-  padding: 32px 16px;
-}
-
 .today-container {
   max-width: 600px;
   margin: 0 auto;
   display: flex;
   flex-direction: column;
   gap: 24px;
-}
-
-.today-header {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.today-header__title {
-  font-family: 'Plus Jakarta Sans', sans-serif;
-  font-size: 32px;
-  font-weight: 800;
-  color: var(--text);
-}
-
-.today-header__date {
-  font-family: 'Inter', sans-serif;
-  font-size: 14px;
-  color: var(--text-muted);
 }
 </style>


### PR DESCRIPTION
## Summary

- Implements Ticket #13: Bento Dashboard Layout
- Adds `BentoGrid` (CSS grid: 4-col desktop / 2-col tablet / 1-col mobile) and `BentoCard` (small/medium/large spans) components
- Adds `AppShell` layout with 240px sidebar (logo, nav icons, active state) and responsive main content header
- Replaces placeholder `DashboardView` with full bento dashboard: Today's Habits, Completion Circle, Best Streak, Weekly Heatmap, Category Donut, Active Habits KPI, This Month KPI
- Updates `HabitsView` and `TodayView` to use `AppShell` for consistent navigation
- Adds `requiresAuth` guard to the `/habits` route
- Adds `bento-grid.test.ts` with 8 tests covering all BentoCard size classes and slot/prop rendering

## Test plan

- [x] `pnpm test:client` — 47 tests pass (7 test files)
- [x] BentoCard renders correct size classes for small/medium/large
- [x] BentoCard renders title, icon, and default slot content
- [x] Header absent when no title or icon provided

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned dashboard with card-based layout displaying habit statistics and metrics
  * Added consistent app-wide navigation sidebar and header across all views
  * Implemented time-of-day greeting and formatted date display in the header
  * Added "New Habit" quick action button for faster habit creation
  * Introduced loading states with skeleton placeholders while data fetches
  * Enhanced responsive design with improved mobile and tablet layouts

* **Tests**
  * Added comprehensive test coverage for dashboard card components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->